### PR TITLE
Removed assumption that Gene.proteinDomains is populated. See comments.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "intermine-apollo",
+  "name": "legumeinfo-graphql-server",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "intermine-apollo",
+      "name": "legumeinfo-graphql-server",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -53,8 +53,8 @@ type Gene {
   description: String
   strain: Strain
   genome: Genome
-  geneFamilyAssignments: [GeneFamilyAssignment]
-  proteinDomains: [ProteinDomain]
+  geneFamilyAssignments: [GeneFamilyAssignment!]
+  proteinDomains: [ProteinDomain!]
 }
 
 type GeneFamilyAssignment {

--- a/schema.graphql
+++ b/schema.graphql
@@ -53,8 +53,8 @@ type Gene {
   description: String
   strain: Strain
   genome: Genome
-  geneFamilyAssignments: [GeneFamilyAssignment!]
-  proteinDomains: [ProteinDomain!]
+  geneFamilyAssignments: [GeneFamilyAssignment]
+  proteinDomains: [ProteinDomain]
 }
 
 type GeneFamilyAssignment {

--- a/src/data-sources/intermine/intermine.models.js
+++ b/src/data-sources/intermine/intermine.models.js
@@ -54,6 +54,10 @@ function response2strains(response) {
 
 
 // the attributes of a Gene in InterMine
+// Note: collections like proteinDomains may be empty, in which case the query returns
+// null if they are in the query. Only attributes, not references or collections, can
+// be guaranteed to exist and result in a non-null response (unless there is an ironclad
+// guarantee that references or collections are populated, which is unlikely).
 const intermineGeneAttributes = [
   'Gene.id',
   'Gene.name',
@@ -61,7 +65,7 @@ const intermineGeneAttributes = [
   'Gene.strain.id',
   'Gene.assemblyVersion',
   //'Gene.geneFamily.id',
-  'Gene.proteinDomains.name',
+  //'Gene.proteinDomains.name',
   //'Gene.proteinDomains.accession',
 ];
 


### PR DESCRIPTION
So, it was a really simple fix, but it actually has important content to it. Your intermineGeneAttributes definition didn't include only attributes; it included `Gene.proteinDomains.name` which is a downstream attribute of a *collection*. If you query the attribute of a collection that is empty, the query will return no results. This is the query that was being run:
```
<query name="" model="genomic" view="Gene.id Gene.name Gene.description Gene.strain.id Gene.assemblyVersion Gene.proteinDomains.name" longDescription="" sortOrder="Gene.name asc">
  <constraint path="Gene.id" op="=" value="431048502"/>
</query>
```
Give it a shot: zipola. However this query
```
<query name="" model="genomic" view="Gene.id Gene.name Gene.description Gene.strain.id Gene.assemblyVersion" longDescription="" sortOrder="Gene.name asc">
  <constraint path="Gene.id" op="=" value="431048502"/>
</query>
```
returns the gene. This particular gene has no associated ProteinDomain, which is common. Also common for  GeneFamilyAssignment.  In general, one must assume that any *reference* or *collection* may be empty and use GraphQL magic to fill those fields if they are not empty.

Which I haven't done, I just fixed this specific issue in intermine.models.js. You'll find that if you run keyword search and ask for genome, for example, you'll still get an error due to null results:

This runs fine:
```
  geneSearch(keyword: $keyword) {
    id
    name
    description
    strain {
      name
    }
  }
```

This doesn't:
```
  geneSearch(keyword: $keyword) {
    id
    name
    description
    strain {
      name
    }
    genome {
      version
    }
  }
```
because genome.version is non-nullable but is getting a null return value.

There's a lot going on here. Bottom line is an InterMine database has lots of holes and one cannot assume anything but attributes of an object are available, and they are often null.

The schema must therefore be built to assume any reference is null and any collection may be empty, knowing that PathQuery will not return any result at all if the query requests an attribute of an object in an empty collection.