### PR TITLE
Added MineWebProperties type and getter, using web-properties service.

### DIFF
--- a/src/data-sources/intermine/api/get-mine-web-properties.js
+++ b/src/data-sources/intermine/api/get-mine-web-properties.js
@@ -1,0 +1,10 @@
+// get the mine's web properties
+async function getMineWebProperties() {
+    return this.webProperties()
+        .then((response) => {
+            return response["web-properties"].project;
+        });
+}
+
+
+module.exports = getMineWebProperties;

--- a/src/data-sources/intermine/api/index.js
+++ b/src/data-sources/intermine/api/index.js
@@ -65,6 +65,9 @@ const getTrait = require('./get-trait.js');
 const getTraits = require('./get-traits.js');
 const searchTraits = require('./search-traits.js');
 
+
+const getMineWebProperties = require('./get-mine-web-properties.js');
+
 module.exports = {
 
     getExpressionSample,
@@ -133,5 +136,7 @@ module.exports = {
     getTrait,
     getTraits,
     searchTraits,
+
+    getMineWebProperties,
 
 };

--- a/src/data-sources/intermine/intermine.api.js
+++ b/src/data-sources/intermine/intermine.api.js
@@ -27,6 +27,13 @@ class IntermineAPI extends RESTDataSource {
         return this.get('search', params);
     }
 
+    async webProperties() {
+        const params = {
+            format: 'json',
+        };
+        return this.get('web-properties', params);
+    }
+
     inputError(msg) {
         throw new UserInputError(msg);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,6 @@ const server = new ApolloServer({
 });
 
 // launch the web server.
-server.listen().then(({url}) => {
+server.listen({port: process.env.PORT || 4000}).then(({url}) => {
   console.log(`Server ready at ${url}`);
 });

--- a/src/resolvers/intermine/index.js
+++ b/src/resolvers/intermine/index.js
@@ -21,6 +21,7 @@ const qtlStudyFactory = require('./qtl-study.js');
 const strainFactory = require('./strain.js');
 const traitFactory = require('./trait.js');
 
+const mineWebPropertiesFactory = require('./mine-web-properties.js');
 
 const factories = [
     expressionSampleFactory,
@@ -43,6 +44,8 @@ const factories = [
     qtlStudyFactory,
     strainFactory,
     traitFactory,
+
+    mineWebPropertiesFactory,
 ];
 
 

--- a/src/resolvers/intermine/mine-web-properties.js
+++ b/src/resolvers/intermine/mine-web-properties.js
@@ -1,0 +1,10 @@
+const mineWebPropertiesFactory = (sourceName) => ({
+    Query: {
+        mineWebProperties: async (_source, {}, { dataSources }) => {
+            return dataSources[sourceName].getMineWebProperties();
+        },
+    },
+});
+
+
+module.exports = mineWebPropertiesFactory;

--- a/src/types/MineWebProperties.graphql
+++ b/src/types/MineWebProperties.graphql
@@ -1,0 +1,21 @@
+# Encapsulates the web-properties.project object returned in the JSON from the mine WebPropertiesServlet.
+# "web-properties": {
+#   "project": {
+#     "subTitle": "A small variety of genomes and annotations to aid code development.",
+#     "citation": "<a href=\"http://www.ncbi.nlm.nih.gov/pubmed/23023984\" target=\"_blank\">Smith RN, et al. InterMine: a flexible data warehouse system for the integration and analysis of heterogeneous biological data. Bioinformatics. 2012 Dec 1;28(23):3163-5.</a>",
+#     "releaseVersion": "5.1.0.1",
+#     "standalone": "true",
+#     "helpLocation": "https://dev.lis.ncgr.org/minimine/help",
+#     "title": "MiniMine",
+#     "sitePrefix": "https://dev.lis.ncgr.org/minimine"
+#   },
+# }
+type MineWebProperties {
+  subTitle: String,
+  citation: String,
+  releaseVersion: String,
+  standalone: String,
+  helpLocation: String,
+  title: String,
+  sitePrefix: String,
+}

--- a/src/types/Query.graphql
+++ b/src/types/Query.graphql
@@ -57,4 +57,7 @@ type Query {
   trait(id: ID!): Trait
   traits(name: String, start: Int, size: Int): [Trait]
 
+
+  mineWebProperties: MineWebProperties
+
 }


### PR DESCRIPTION
Added an API method to intermine.api.js to hit the /web-properties service on the mine, which Julie Sullivan so presciently wrote years ago. This PR is against mine-5.1.0.2-schema of course, but only contains that standalone update which is built on the new layout.