### PR TITLE
Update intermine.pathquery.js

### DIFF
--- a/src/data-sources/intermine/intermine.pathquery.js
+++ b/src/data-sources/intermine/intermine.pathquery.js
@@ -12,7 +12,7 @@ function intermineConstraint(path, op, value) {
 function interminePathQuery(viewAttributes, sortBy, constraints=[]) {
   const view = viewAttributes.join(' ');
   const constraint = constraints.join('');
-  return `<query model='genomic' view='${view}' sortOrder='${sortBy} ASC'>${constraint}</query>`;
+  return `<query model='genomic' view='${view}' sortOrder='${sortBy}'>${constraint}</query>`;
 }
 
 


### PR DESCRIPTION
Remove hardcoded ASC from ${sortOrder} so we can (1) have descending sort order and (2) have multiple sorting fields, e.g. "QTL.trait.name ASC QTL.linkageGroup.identifier ASC". This is non-breaking since ASC is assumed if not present.