### PR TITLE
Still had lisIntermineAPI hardcoded in a few resolvers; plus a fix.

### DIFF
--- a/src/data-sources/intermine/api/get-gwas-for-trait.js
+++ b/src/data-sources/intermine/api/get-gwas-for-trait.js
@@ -1,0 +1,22 @@
+// get the GWAS for a Trait
+async function getGWASForTrait({trait}={}) {
+    if (trait) {
+        const constraints = [this.pathquery.intermineConstraint('GWAS.results.trait.id', '=', trait.id)];
+        const query = this.pathquery.interminePathQuery(
+            this.models.intermineGWASAttributes,
+            this.models.intermineGWASSort,
+            constraints,
+        );
+        return this.pathQuery(query)
+            .then((response) => this.models.response2gwas(response))
+            .then((gwas) => {
+                if (gwas.length) {
+                    return gwas[0];
+                } else {
+                    return null;
+                }
+            });
+    }
+}
+
+module.exports = getGWASForTrait;

--- a/src/data-sources/intermine/api/get-gwas.js
+++ b/src/data-sources/intermine/api/get-gwas.js
@@ -17,25 +17,4 @@ async function getGWAS(id) {
         });
 }
 
-// get the GWAS for a Trait
-async function getGWAS({trait}={}) {
-    if (trait) {
-        const constraints = [this.pathquery.intermineConstraint('GWAS.results.trait.id', '=', trait.id)];
-        const query = this.pathquery.interminePathQuery(
-            this.models.intermineGWASAttributes,
-            this.models.intermineGWASSort,
-            constraints,
-        );
-        return this.pathQuery(query)
-            .then((response) => this.models.response2gwas(response))
-            .then((gwas) => {
-                if (gwas.length) {
-                    return gwas[0];
-                } else {
-                    return null;
-                }
-            });
-    }
-}
-
 module.exports = getGWAS;

--- a/src/data-sources/intermine/api/get-phylonode-for-protein.js
+++ b/src/data-sources/intermine/api/get-phylonode-for-protein.js
@@ -1,0 +1,22 @@
+// get a Phylonode for a Protein
+async function getPhylonodeForProtein({protein}={}) {
+    if (protein) {
+        const constraints = [this.pathquery.intermineConstraint('Phylonode.protein.id', '=', protein.id)];
+        const query = this.pathquery.interminePathQuery(
+            this.models.interminePhylonodeAttributes,
+            this.models.interminePhylonodeSort,
+            constraints,
+        );
+        return this.pathQuery(query)
+            .then((response) => this.models.response2phylonodes(response))
+            .then((phylonodes) => {
+                if (phylonodes.length) {
+                    return phylonodes[0];
+                } else {
+                    return null;
+                }
+            });
+    }
+}
+
+module.exports = getPhylonodeForProtein;

--- a/src/data-sources/intermine/api/get-phylonode.js
+++ b/src/data-sources/intermine/api/get-phylonode.js
@@ -17,26 +17,4 @@ async function getPhylonode(id) {
         });
 }
 
-// get a Phylonode for a Protein
-async function getPhylonode({protein}={}) {
-    if (protein) {
-        const constraints = [this.pathquery.intermineConstraint('Phylonode.protein.id', '=', protein.id)];
-        const query = this.pathquery.interminePathQuery(
-            this.models.interminePhylonodeAttributes,
-            this.models.interminePhylonodeSort,
-            constraints,
-        );
-        return this.pathQuery(query)
-            .then((response) => this.models.response2phylonodes(response))
-            .then((phylonodes) => {
-                if (phylonodes.length) {
-                    return phylonodes[0];
-                } else {
-                    return null;
-                }
-            });
-    }
-}
-
-
 module.exports = getPhylonode;

--- a/src/data-sources/intermine/api/get-qtl-study-for-trait.js
+++ b/src/data-sources/intermine/api/get-qtl-study-for-trait.js
@@ -1,0 +1,22 @@
+// get the QTLStudy for a Trait
+async function getQTLStudyForTrait({trait}={}) {
+    if (trait) {
+        const constraints = [this.pathquery.intermineConstraint('QTLStudy.qtls.trait.id', '=', trait.id)];
+        const query = this.pathquery.interminePathQuery(
+            this.models.intermineQTLStudyAttributes,
+            this.models.intermineQTLStudySort,
+            constraints,
+        );
+        return this.pathQuery(query)
+            .then((response) => this.models.response2qtlStudies(response))
+            .then((qtlStudies) => {
+                if (qtlStudies.length) {
+                    return qtlStudies[0];
+                } else {
+                    return null;
+                }
+            });
+    }
+}
+
+module.exports = getQTLStudyForTrait;

--- a/src/data-sources/intermine/api/get-qtl-study.js
+++ b/src/data-sources/intermine/api/get-qtl-study.js
@@ -17,26 +17,4 @@ async function getQTLStudy(id) {
         });
 }
 
-// get the QTLStudy for a Trait
-async function getQTLStudy({trait}={}) {
-    if (trait) {
-        const constraints = [this.pathquery.intermineConstraint('QTLStudy.qtls.trait.id', '=', trait.id)];
-        const query = this.pathquery.interminePathQuery(
-            this.models.intermineQTLStudyAttributes,
-            this.models.intermineQTLStudySort,
-            constraints,
-        );
-        return this.pathQuery(query)
-            .then((response) => this.models.response2qtlStudies(response))
-            .then((qtlStudies) => {
-                if (qtlStudies.length) {
-                    return qtlStudies[0];
-                } else {
-                    return null;
-                }
-            });
-    }
-}
-
-
 module.exports = getQTLStudy;

--- a/src/data-sources/intermine/api/index.js
+++ b/src/data-sources/intermine/api/index.js
@@ -34,6 +34,7 @@ const getGeneticMarker = require('./get-genetic-marker.js');
 const getGeneticMarkers = require('./get-genetic-markers.js');
 
 const getGWAS = require('./get-gwas.js');
+const getGWASForTrait = require('./get-gwas-for-trait.js');
 const searchGWASes = require('./search-gwases.js');
 
 const getGWASResult = require('./get-gwas-result.js');
@@ -68,6 +69,7 @@ const getPathway = require('./get-pathway.js');
 const getPathways = require('./get-pathways.js');
 
 const getPhylonode = require('./get-phylonode.js');
+const getPhylonodeForProtein = require('./get-phylonode-for-protein.js');
 const getPhylonodes = require('./get-phylonodes.js');
 
 const getPhylotree = require('./get-phylotree.js');
@@ -89,6 +91,7 @@ const getQTLs = require('./get-qtls.js');
 const searchQTLs = require('./search-qtls.js');
 
 const getQTLStudy = require('./get-qtl-study.js');
+const getQTLStudyForTrait = require('./get-qtl-study-for-trait.js');
 const searchQTLStudies  = require('./search-qtl-studies.js');
 
 const getSyntenicRegion = require('./get-syntenic-region.js');
@@ -144,6 +147,7 @@ module.exports = {
     getGeneticMarkers,
 
     getGWAS,
+    getGWASForTrait,
     searchGWASes,
     
     getGWASResult,
@@ -178,6 +182,7 @@ module.exports = {
     getPathways,
     
     getPhylonode,
+    getPhylonodeForProtein,
     getPhylonodes,
 
     getPhylotree,
@@ -199,6 +204,7 @@ module.exports = {
     searchQTLs,
     
     getQTLStudy,
+    getQTLStudyForTrait,
     searchQTLStudies,
 
     getStrain,

--- a/src/data-sources/intermine/models/phylonode.js
+++ b/src/data-sources/intermine/models/phylonode.js
@@ -17,6 +17,7 @@ const interminePhylonodeAttributes = [
     'Phylonode.length',
     'Phylonode.numChildren',
     'Phylonode.isLeaf',
+    'Phylonode.protein.id',
     'Phylonode.tree.id',
     'Phylonode.parent.id',
 ];
@@ -29,6 +30,7 @@ const graphqlPhylonodeAttributes = [
     'length',
     'numChildren',
     'isLeaf',
+    'proteinId',
     'treeId',
     'parentId',
 ];

--- a/src/resolvers/intermine/expression-sample.js
+++ b/src/resolvers/intermine/expression-sample.js
@@ -1,7 +1,7 @@
 const expressionSampleFactory = (sourceName) => ({
     Query: {
         expressionSample:  async (_source, { id }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getExpressionSample(id);
+            return dataSources[sourceName].getExpressionSample(id);
         },
         expressionSamples: async (_source, { description, start, size }, { dataSources }) => {
             const args = {
@@ -14,7 +14,7 @@ const expressionSampleFactory = (sourceName) => ({
     },
     ExpressionSample: {
         source: async (expressionSample, { }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getExpressionSource(expressionSample.sourceId);
+            return dataSources[sourceName].getExpressionSource(expressionSample.sourceId);
         },
         ontologyAnnotations: async (expressionSample, { start, size }, { dataSources }) => {
             const args = {

--- a/src/resolvers/intermine/expression-source.js
+++ b/src/resolvers/intermine/expression-source.js
@@ -1,7 +1,7 @@
 const expressionSampleFactory = (sourceName) => ({
     Query: {
         expressionSource:  async (_source, { id }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getExpressionSource(id);
+            return dataSources[sourceName].getExpressionSource(id);
         },
         expressionSources: async (_source, { description, start, size }, { dataSources }) => {
             const args = {
@@ -14,13 +14,13 @@ const expressionSampleFactory = (sourceName) => ({
     },
     ExpressionSource: {
         organism: async (expressionSource, { }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getOrganism(expressionSource.organismId);
+            return dataSources[sourceName].getOrganism(expressionSource.organismId);
         },
         strain: async (expressionSource, { }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getStrain(expressionSource.strainId);
+            return dataSources[sourceName].getStrain(expressionSource.strainId);
         },
         dataSet: async (expressionSource, { }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getDataSet(expressionSource.dataSetId);
+            return dataSources[sourceName].getDataSet(expressionSource.dataSetId);
         },
         samples: async (expressionSource, { start, size }, { dataSources }) => {
             const args = {expressionSource, start, size};

--- a/src/resolvers/intermine/genetic-map.js
+++ b/src/resolvers/intermine/genetic-map.js
@@ -1,7 +1,7 @@
 const geneticMapFactory = (sourceName) => ({
     Query: {
         geneticMap:  async (_source, { id }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getGeneticMap(id);
+            return dataSources[sourceName].getGeneticMap(id);
         },
         geneticMaps: async (_source, { description, start, size }, { dataSources }) => {
             const args = {
@@ -14,7 +14,7 @@ const geneticMapFactory = (sourceName) => ({
     },
     GeneticMap: {
         organism: async (geneticMap, { }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getOrganism(geneticMap.organismId);
+            return dataSources[sourceName].getOrganism(geneticMap.organismId);
         },
         dataSets: async (geneticMap, { start, size }, { dataSources }) => {
             const args = {
@@ -30,7 +30,7 @@ const geneticMapFactory = (sourceName) => ({
                 start,
                 size,
             };
-            return dataSources.lisIntermineAPI.getLinkageGroups(args);
+            return dataSources[sourceName].getLinkageGroups(args);
         },
         publications: async (geneticMap, { start, size }, { dataSources }) => {
             const args = {

--- a/src/resolvers/intermine/genetic-marker.js
+++ b/src/resolvers/intermine/genetic-marker.js
@@ -1,7 +1,7 @@
 const geneticMarkerFactory = (sourceName) => ({
     Query: {
         geneticMarker:  async (_source, { id }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getGeneticMarker(id);
+            return dataSources[sourceName].getGeneticMarker(id);
         },
         // geneticMarkers: async (_source, { description, start, size }, { dataSources }) => {
         //     const args = {
@@ -33,7 +33,7 @@ const geneticMarkerFactory = (sourceName) => ({
                 start,
                 size,
             };
-            return dataSources.lisIntermineAPI.getQTLs(args);
+            return dataSources[sourceName].getQTLs(args);
         },
         gwasResults: async (geneticMarker, { start, size }, { dataSources }) => {
             const args = {
@@ -41,7 +41,7 @@ const geneticMarkerFactory = (sourceName) => ({
                 start,
                 size,
             };
-            return dataSources.lisIntermineAPI.getGWASResults(args);
+            return dataSources[sourceName].getGWASResults(args);
         },
         linkageGroupPositions: async (geneticMarker, { start, size }, { dataSources }) => {
             const args = {
@@ -49,7 +49,7 @@ const geneticMarkerFactory = (sourceName) => ({
                 start,
                 size,
             };
-            return dataSources.lisIntermineAPI.getLinkageGroupPositions(args);
+            return dataSources[sourceName].getLinkageGroupPositions(args);
         },
         locations: async (geneticMarker, { start, size }, { dataSources }) => {
             const args = {

--- a/src/resolvers/intermine/linkage-group-position.js
+++ b/src/resolvers/intermine/linkage-group-position.js
@@ -1,12 +1,12 @@
 const linkageGroupPositionFactory = (sourceName) => ({
     Query: {
         linkageGroupPosition:  async (_source, { id }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getLinkageGroupPosition(id);
+            return dataSources[sourceName].getLinkageGroupPosition(id);
         },
     },
     LinkageGroupPosition: {
         linkageGroup: async (linkageGroupPosition, { }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getLinkageGroup(linkageGroupPosition.linkageGroupId);
+            return dataSources[sourceName].getLinkageGroup(linkageGroupPosition.linkageGroupId);
         },
     },
 });

--- a/src/resolvers/intermine/linkage-group.js
+++ b/src/resolvers/intermine/linkage-group.js
@@ -1,12 +1,12 @@
 const linkageGroupFactory = (sourceName) => ({
     Query: {
         linkageGroup:  async (_source, { id }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getLinkageGroup(id);
+            return dataSources[sourceName].getLinkageGroup(id);
         },
     },
     LinkageGroup: {
         geneticMap: async (linkageGroup, { }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getGeneticMap(linkageGroup.geneticMapId);
+            return dataSources[sourceName].getGeneticMap(linkageGroup.geneticMapId);
         },
         dataSets: async (linkageGroup, { start, size }, { dataSources }) => {
             const args = {
@@ -22,7 +22,7 @@ const linkageGroupFactory = (sourceName) => ({
                 start,
                 size,
             };
-            return dataSources.lisIntermineAPI.getQTLs(args);
+            return dataSources[sourceName].getQTLs(args);
         },
     },
 });

--- a/src/resolvers/intermine/phylonode.js
+++ b/src/resolvers/intermine/phylonode.js
@@ -5,6 +5,9 @@ const phyloNodeFactory = (sourceName) => ({
         },
     },
     Phylonode: {
+        protein: async(phylonode, { }, { dataSources }) => {
+            return dataSources[sourceName].getProtein(phylonode.proteinId);
+        },
         tree: async(phylonode, { }, { dataSources }) => {
             return dataSources[sourceName].getPhylotree(phylonode.treeId);
         },

--- a/src/resolvers/intermine/protein.js
+++ b/src/resolvers/intermine/protein.js
@@ -23,7 +23,7 @@ const proteinFactory = (sourceName) => ({
             const args = {
                 protein: protein
             };
-            return dataSources[sourceName].getPhylonode(args);
+            return dataSources[sourceName].getPhylonodeForProtein(args);
         },
         dataSets: async (protein, { start, size }, { dataSources }) => {
             const args = {

--- a/src/resolvers/intermine/qtl-study.js
+++ b/src/resolvers/intermine/qtl-study.js
@@ -1,7 +1,7 @@
 const qtlStudyFactory = (sourceName) => ({
     Query: {
         qtlStudy:  async (_source, { id }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getQTLStudy(id);
+            return dataSources[sourceName].getQTLStudy(id);
         },
         qtlStudies: async (_source, { description, start, size }, { dataSources }) => {
             const args = {
@@ -14,10 +14,10 @@ const qtlStudyFactory = (sourceName) => ({
     },
     QTLStudy: {
         organism: async (qtlStudy, { }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getOrganism(qtlStudy.organismId);
+            return dataSources[sourceName].getOrganism(qtlStudy.organismId);
         },
         dataSet: async (qtlStudy, { }, { dataSources }) => {
-            return dataSources.lisIntermineAPI.getDataSet(qtlStudy.dataSetId);
+            return dataSources[sourceName].getDataSet(qtlStudy.dataSetId);
         },
         qtls: async (qtlStudy, { start, size }, { dataSources }) => {
             const args = {
@@ -25,7 +25,7 @@ const qtlStudyFactory = (sourceName) => ({
                 start,
                 size,
             };
-            return dataSources.lisIntermineAPI.getQTLs(args);
+            return dataSources[sourceName].getQTLs(args);
         },
         publications: async (qtlStudy, { start, size }, { dataSources }) => {
             const args = {

--- a/src/resolvers/intermine/trait.js
+++ b/src/resolvers/intermine/trait.js
@@ -16,7 +16,7 @@ const traitFactory = (sourceName) => ({
             const args = {
                 trait: trait
             };
-            return dataSources[sourceName].getQTLStudy(args);
+            return dataSources[sourceName].getQTLStudyForTrait(args);
         },
         qtls: async (trait, { start, size }, { dataSources }) => {
             const args = {trait, start, size};
@@ -26,7 +26,7 @@ const traitFactory = (sourceName) => ({
             const args = {
                 trait: trait
             };
-            return dataSources[sourceName].getGWAS(args);
+            return dataSources[sourceName].getGWASForTrait(args);
         },
         gwasResults: async (trait, { start, size }, { dataSources }) => {
             const args = {trait, start, size};

--- a/src/types/Phylonode.graphql
+++ b/src/types/Phylonode.graphql
@@ -17,7 +17,7 @@ type Phylonode {
   length: Float
   numChildren: Int
   isLeaf: Boolean
-  # protein: Protein
+  protein: Protein
   tree: Phylotree
   parent: Phylonode
   children: [Phylonode]


### PR DESCRIPTION
More boring stuff on which I'll go MAJOR ROGUE and merge myself because this is really too trivial to be reviewed. But, tested. (The fix has to do with my misunderstanding of Javascript function typing - I thought Javascript was like Java in that you can have two methods with the same name but different parameters. Apparently not - the latter definition trumps without any error that I could see. So I split them apart with renaming.)