### PR TITLE
Fixed bug in how qtlStudy property of a trait is resolved.

### DIFF
--- a/src/resolvers/intermine/trait.ts
+++ b/src/resolvers/intermine/trait.ts
@@ -17,10 +17,7 @@ export const traitFactory = (sourceName: keyof DataSources): ResolverMap => ({
             return dataSources[sourceName].getDataSet(trait.dataSetId);
         },
         qtlStudy: async (trait, _, { dataSources }) => {
-            const args = {
-                trait: trait
-            };
-            return dataSources[sourceName].getQTLStudyForTrait(args);
+            return dataSources[sourceName].getQTLStudyForTrait(trait);
         },
         qtls: async (trait, _, { dataSources }) => {
             const args = {trait};


### PR DESCRIPTION
The data source method used to take the trait as the property of an object parameter but the TypeScript migration made the trait its own parameter. The trait qtlStudy resolver was not updated during the migration to reflect this. This PR fixes that oversight.