### PR TITLE
Remove defaultPaginationOptions. start, size may be null returning all query records.

### DIFF
--- a/create-search-query.md
+++ b/create-search-query.md
@@ -35,7 +35,7 @@ import {
   interminePublicationSort,
   response2publications,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchPublicationsOptions = {
@@ -47,8 +47,8 @@ export type SearchPublicationsOptions = {
 export async function searchPublications(
   {
     title,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size}: SearchPublicationsOptions,
+    start,
+    size}: SearchPublicationsOptions,
 ): Promise<GraphQLPublication[]> {
     const constraints = [];
     if (title) {

--- a/src/data-sources/index.ts
+++ b/src/data-sources/index.ts
@@ -11,6 +11,6 @@ export type DataSources = {
 export const dataSources = (cache: KeyValueCache): DataSources => {
   const config = {cache};
   return {
-    lisIntermineAPI: new IntermineAPI('https://mines.legumeinfo.org/minimine/service', config),
+    lisIntermineAPI: new IntermineAPI('https://mines.legumeinfo.org/legumemine/service', config),
   };
 };

--- a/src/data-sources/intermine/api/get-authors.ts
+++ b/src/data-sources/intermine/api/get-authors.ts
@@ -1,27 +1,27 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLAuthor,
-  GraphQLPublication,
-  IntermineAuthorResponse,
-  intermineAuthorAttributes,
-  intermineAuthorSort,
-  response2authors,
+    GraphQLAuthor,
+    GraphQLPublication,
+    IntermineAuthorResponse,
+    intermineAuthorAttributes,
+    intermineAuthorSort,
+    response2authors,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GetAuthorsOptions = {
-  publication?: GraphQLPublication;
+    publication?: GraphQLPublication;
 } & PaginationOptions;
 
 
 // get Authors associated with an Publication
 export async function getAuthors(
-  {
-    publication,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GetAuthorsOptions,
+    {
+        publication,
+        start,
+        size,
+    }: GetAuthorsOptions,
 ): Promise<GraphQLAuthor[]> {
     const constraints = [];
     if (publication) {

--- a/src/data-sources/intermine/api/get-chromosome.ts
+++ b/src/data-sources/intermine/api/get-chromosome.ts
@@ -9,6 +9,7 @@ import {
 
 
 // get a Chromosome by ID
+// does NOT throw an error if the chromosome is not found, since this happens when the identifier belongs to a supercontig
 export async function getChromosome(identifier: string): Promise<GraphQLChromosome> {
     const constraints = [intermineConstraint('Chromosome.primaryIdentifier', '=', identifier)];
     const query = interminePathQuery(
@@ -19,10 +20,10 @@ export async function getChromosome(identifier: string): Promise<GraphQLChromoso
     return this.pathQuery(query)
         .then((response: IntermineChromosomeResponse) => response2chromosomes(response))
         .then((chromosomes: Array<GraphQLChromosome>) => {
-            if (!chromosomes.length) {
-                const msg = `Chromosome with primaryIdentifier '${identifier}' not found`;
-                this.inputError(msg);
+            if (chromosomes.length) {
+                return chromosomes[0];
+            } else {
+                return null;
             }
-            return chromosomes[0];
         });
 }

--- a/src/data-sources/intermine/api/get-data-sets.ts
+++ b/src/data-sources/intermine/api/get-data-sets.ts
@@ -1,48 +1,48 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLBioEntity,
-  GraphQLDataSet,
-  GraphQLGeneticMap,
-  GraphQLLinkageGroup,
-  GraphQLLocation,
-  GraphQLOntology,
-  GraphQLOntologyAnnotation,
-  GraphQLOntologyTerm,
-  GraphQLPathway,
-  GraphQLPhylotree,
-  GraphQLSyntenyBlock,
-  IntermineDataSetResponse,
-  intermineDataSetAttributes,
-  intermineDataSetSort,
-  intermineGeneticMapDataSetAttributes,
-  intermineGeneticMapDataSetSort,
-  intermineLinkageGroupDataSetAttributes,
-  intermineLinkageGroupDataSetSort,
-  intermineLocationDataSetAttributes,
-  intermineLocationDataSetSort,
-  intermineOntologyAnnotationDataSetAttributes,
-  intermineOntologyAnnotationDataSetSort,
-  intermineOntologyDataSetAttributes,
-  intermineOntologyDataSetSort,
-  intermineOntologyTermDataSetAttributes,
-  intermineOntologyTermDataSetSort,
-  interminePathwayDataSetAttributes,
-  interminePathwayDataSetSort,
-  interminePhylotreeDataSetAttributes,
-  interminePhylotreeDataSetSort,
-  intermineSyntenyBlockDataSetAttributes,
-  intermineSyntenyBlockDataSetSort,
-  response2dataSets,
+    GraphQLBioEntity,
+    GraphQLDataSet,
+    GraphQLGeneticMap,
+    GraphQLLinkageGroup,
+    GraphQLLocation,
+    GraphQLOntology,
+    GraphQLOntologyAnnotation,
+    GraphQLOntologyTerm,
+    GraphQLPathway,
+    GraphQLPhylotree,
+    GraphQLSyntenyBlock,
+    IntermineDataSetResponse,
+    intermineDataSetAttributes,
+    intermineDataSetSort,
+    intermineGeneticMapDataSetAttributes,
+    intermineGeneticMapDataSetSort,
+    intermineLinkageGroupDataSetAttributes,
+    intermineLinkageGroupDataSetSort,
+    intermineLocationDataSetAttributes,
+    intermineLocationDataSetSort,
+    intermineOntologyAnnotationDataSetAttributes,
+    intermineOntologyAnnotationDataSetSort,
+    intermineOntologyDataSetAttributes,
+    intermineOntologyDataSetSort,
+    intermineOntologyTermDataSetAttributes,
+    intermineOntologyTermDataSetSort,
+    interminePathwayDataSetAttributes,
+    interminePathwayDataSetSort,
+    interminePhylotreeDataSetAttributes,
+    interminePhylotreeDataSetSort,
+    intermineSyntenyBlockDataSetAttributes,
+    intermineSyntenyBlockDataSetSort,
+    response2dataSets,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export async function getDataSetsForBioEntity(
-  bioEntity: GraphQLBioEntity,
-  {
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: PaginationOptions,
+    bioEntity: GraphQLBioEntity,
+    {
+        start,
+        size,
+    }: PaginationOptions,
 ): Promise<GraphQLDataSet> {
     const options = {start, size};
     const constraints = [intermineConstraint('DataSet.bioEntities.id', '=', bioEntity.id)];
@@ -57,11 +57,11 @@ export async function getDataSetsForBioEntity(
 
 
 export async function getDataSetsForGeneticMap(
-  geneticMap: GraphQLGeneticMap,
-  {
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: PaginationOptions,
+    geneticMap: GraphQLGeneticMap,
+    {
+        start,
+        size,
+    }: PaginationOptions,
 ): Promise<GraphQLDataSet> {
     const options = {start, size};
     const constraints = [intermineConstraint('GeneticMap.id', '=', geneticMap.id)];
@@ -76,11 +76,11 @@ export async function getDataSetsForGeneticMap(
 
 
 export async function getDataSetsForLinkageGroup(
-  linkageGroup: GraphQLLinkageGroup,
-  {
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: PaginationOptions,
+    linkageGroup: GraphQLLinkageGroup,
+    {
+        start,
+        size,
+    }: PaginationOptions,
 ): Promise<GraphQLDataSet> {
     const options = {start, size};
     const constraints = [intermineConstraint('LinkageGroup.id', '=', linkageGroup.id)];
@@ -95,11 +95,11 @@ export async function getDataSetsForLinkageGroup(
 
 
 export async function getDataSetsForLocation(
-  location: GraphQLLocation,
-  {
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: PaginationOptions,
+    location: GraphQLLocation,
+    {
+        start,
+        size,
+    }: PaginationOptions,
 ): Promise<GraphQLDataSet> {
     const options = {start, size};
     const constraints = [intermineConstraint('Location.id', '=', location.id)];
@@ -114,11 +114,11 @@ export async function getDataSetsForLocation(
 
 
 export async function getDataSetsForOntology(
-  ontology: GraphQLOntology,
-  {
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: PaginationOptions,
+    ontology: GraphQLOntology,
+    {
+        start,
+        size,
+    }: PaginationOptions,
 ): Promise<GraphQLDataSet> {
     const options = {start, size};
     const constraints = [intermineConstraint('Ontology.id', '=', ontology.id)];
@@ -133,11 +133,11 @@ export async function getDataSetsForOntology(
 
 
 export async function getDataSetsForOntologyAnnotation(
-  ontologyAnnotation: GraphQLOntologyAnnotation,
-  {
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: PaginationOptions,
+    ontologyAnnotation: GraphQLOntologyAnnotation,
+    {
+        start,
+        size,
+    }: PaginationOptions,
 ): Promise<GraphQLDataSet> {
     const options = {start, size};
     const constraints = [intermineConstraint('OntologyAnnotation.id', '=', ontologyAnnotation.id)];
@@ -152,11 +152,11 @@ export async function getDataSetsForOntologyAnnotation(
 
 
 export async function getDataSetsForOntologyTerm(
-  ontologyTerm: GraphQLOntologyTerm,
-  {
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: PaginationOptions,
+    ontologyTerm: GraphQLOntologyTerm,
+    {
+        start,
+        size,
+    }: PaginationOptions,
 ): Promise<GraphQLDataSet> {
     const options = {start, size};
     const constraints = [intermineConstraint('OntologyTerm.id', '=', ontologyTerm.id)];
@@ -171,11 +171,11 @@ export async function getDataSetsForOntologyTerm(
 
 
 export async function getDataSetsForPathway(
-  pathway: GraphQLPathway,
-  {
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: PaginationOptions,
+    pathway: GraphQLPathway,
+    {
+        start,
+        size,
+    }: PaginationOptions,
 ): Promise<GraphQLDataSet> {
     const options = {start, size};
     const constraints = [intermineConstraint('Pathway.id', '=', pathway.id)];
@@ -190,11 +190,11 @@ export async function getDataSetsForPathway(
 
 
 export async function getDataSetsForPhylotree(
-  phylotree: GraphQLPhylotree,
-  {
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: PaginationOptions,
+    phylotree: GraphQLPhylotree,
+    {
+        start,
+        size,
+    }: PaginationOptions,
 ): Promise<GraphQLDataSet> {
     const options = {start, size};
     const constraints = [intermineConstraint('Phylotree.id', '=', phylotree.id)];
@@ -209,11 +209,11 @@ export async function getDataSetsForPhylotree(
 
 
 export async function getDataSetsForSyntenyBlock(
-  syntenyBlock: GraphQLSyntenyBlock,
-  {
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: PaginationOptions,
+    syntenyBlock: GraphQLSyntenyBlock,
+    {
+        start,
+        size,
+    }: PaginationOptions,
 ): Promise<GraphQLDataSet> {
     const options = {start, size};
     const constraints = [intermineConstraint('SyntenyBlock.id', '=', syntenyBlock.id)];

--- a/src/data-sources/intermine/api/get-expression-samples.ts
+++ b/src/data-sources/intermine/api/get-expression-samples.ts
@@ -1,27 +1,27 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLExpressionSample,
-  GraphQLExpressionSource,
-  IntermineExpressionSampleResponse,
-  intermineExpressionSampleAttributes,
-  intermineExpressionSampleSort,
-  response2expressionSamples,
+    GraphQLExpressionSample,
+    GraphQLExpressionSource,
+    IntermineExpressionSampleResponse,
+    intermineExpressionSampleAttributes,
+    intermineExpressionSampleSort,
+    response2expressionSamples,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GetExpressionSamplesOptions = {
-  expressionSource?: GraphQLExpressionSource;
+    expressionSource?: GraphQLExpressionSource;
 } & PaginationOptions;
 
 
 // get ExpressionSamples for an ExpressionSource
 export async function getExpressionSamples(
-  {
-    expressionSource,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GetExpressionSamplesOptions,
+    {
+        expressionSource,
+        start,
+        size,
+    }: GetExpressionSamplesOptions,
 ): Promise<GraphQLExpressionSample[]> {
     const constraints = [];
     if (expressionSource) {

--- a/src/data-sources/intermine/api/get-gene-families.ts
+++ b/src/data-sources/intermine/api/get-gene-families.ts
@@ -1,27 +1,27 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLGeneFamily,
-  GraphQLProteinDomain,
-  IntermineGeneFamilyResponse,
-  intermineGeneFamilyAttributes,
-  intermineGeneFamilySort,
-  response2geneFamilies,
+    GraphQLGeneFamily,
+    GraphQLProteinDomain,
+    IntermineGeneFamilyResponse,
+    intermineGeneFamilyAttributes,
+    intermineGeneFamilySort,
+    response2geneFamilies,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GeneGeneFamiliesOptions = {
-  proteinDomain?: GraphQLProteinDomain;
+    proteinDomain?: GraphQLProteinDomain;
 } & PaginationOptions;
 
 
 // get GeneFamilies for a ProteinDomain
 export async function getGeneFamilies(
-  {
-    proteinDomain,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GeneGeneFamiliesOptions,
+    {
+        proteinDomain,
+        start,
+        size,
+    }: GeneGeneFamiliesOptions,
 ): Promise<GraphQLGeneFamily[]> {
     const constraints = [];
     if (proteinDomain) {

--- a/src/data-sources/intermine/api/get-gene-family-tallies.ts
+++ b/src/data-sources/intermine/api/get-gene-family-tallies.ts
@@ -1,27 +1,27 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLGeneFamily,
-  GraphQLGeneFamilyTally,
-  IntermineGeneFamilyTallyResponse,
-  intermineGeneFamilyTallyAttributes,
-  intermineGeneFamilyTallySort,
-  response2geneFamilyTallies,
+    GraphQLGeneFamily,
+    GraphQLGeneFamilyTally,
+    IntermineGeneFamilyTallyResponse,
+    intermineGeneFamilyTallyAttributes,
+    intermineGeneFamilyTallySort,
+    response2geneFamilyTallies,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchGeneFamilyTalliesOptions = {
-  geneFamily?: GraphQLGeneFamily;
+    geneFamily?: GraphQLGeneFamily;
 } & PaginationOptions;
 
 
 // get GeneFamilyTallies associated with a GeneFamily
 export async function getGeneFamilyTallies(
-  {
-    geneFamily,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchGeneFamilyTalliesOptions,
+    {
+        geneFamily,
+        start,
+        size,
+    }: SearchGeneFamilyTalliesOptions,
 ): Promise<GraphQLGeneFamilyTally[]> {
     const constraints = [];
     if (geneFamily) {

--- a/src/data-sources/intermine/api/get-genes.ts
+++ b/src/data-sources/intermine/api/get-genes.ts
@@ -1,33 +1,33 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLGene,
-  GraphQLGeneFamily,
-  GraphQLProtein,
-  GraphQLProteinDomain,
-  IntermineGeneResponse,
-  intermineGeneAttributes,
-  intermineGeneSort,
-  response2genes,
+    GraphQLGene,
+    GraphQLGeneFamily,
+    GraphQLProtein,
+    GraphQLProteinDomain,
+    IntermineGeneResponse,
+    intermineGeneAttributes,
+    intermineGeneSort,
+    response2genes,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GetGenesOptions = {
-  protein?: GraphQLProtein;
-  geneFamily?: GraphQLGeneFamily;
-  proteinDomain?: GraphQLProteinDomain;
+    protein?: GraphQLProtein;
+    geneFamily?: GraphQLGeneFamily;
+    proteinDomain?: GraphQLProteinDomain;
 } & PaginationOptions;
 
 
 // get Genes associated with a Protein, GeneFamily, ProteinDomain
 export async function getGenes(
-  {
-    protein,
-    geneFamily,
-    proteinDomain,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GetGenesOptions,
+    {
+        protein,
+        geneFamily,
+        proteinDomain,
+        start,
+        size,
+    }: GetGenesOptions,
 ): Promise<GraphQLGene> {
     const constraints = [];
     if (protein) {

--- a/src/data-sources/intermine/api/get-genetic-markers.ts
+++ b/src/data-sources/intermine/api/get-genetic-markers.ts
@@ -1,27 +1,27 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLGeneticMarker,
-  GraphQLQTL,
-  IntermineGeneticMarkerResponse,
-  intermineGeneticMarkerAttributes,
-  intermineGeneticMarkerSort,
-  response2geneticMarkers,
+    GraphQLGeneticMarker,
+    GraphQLQTL,
+    IntermineGeneticMarkerResponse,
+    intermineGeneticMarkerAttributes,
+    intermineGeneticMarkerSort,
+    response2geneticMarkers,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GetGeneticMarkersOptions = {
-  qtl?: GraphQLQTL;
+    qtl?: GraphQLQTL;
 } & PaginationOptions;
 
 
 // get GeneticMarkers for a QTL
 export async function getGeneticMarkers(
-  {
-    qtl,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GetGeneticMarkersOptions,
+    {
+        qtl,
+        start,
+        size,
+    }: GetGeneticMarkersOptions,
 ): Promise<GraphQLGeneticMarker[]> {
     const constraints = [];
     if (qtl) {

--- a/src/data-sources/intermine/api/get-ontology-annotations.ts
+++ b/src/data-sources/intermine/api/get-ontology-annotations.ts
@@ -1,27 +1,27 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLAnnotatable,
-  GraphQLOntologyAnnotation,
-  IntermineOntologyAnnotationResponse,
-  intermineOntologyAnnotationAttributes,
-  intermineOntologyAnnotationSort,
-  response2ontologyAnnotations,
+    GraphQLAnnotatable,
+    GraphQLOntologyAnnotation,
+    IntermineOntologyAnnotationResponse,
+    intermineOntologyAnnotationAttributes,
+    intermineOntologyAnnotationSort,
+    response2ontologyAnnotations,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GetOntologyAnnotationsOptions = {
-  annotatable?: GraphQLAnnotatable;
+    annotatable?: GraphQLAnnotatable;
 } & PaginationOptions;
 
 
 // get OntologyAnnotations for any type that extends Annotatable
 export async function getOntologyAnnotations(
-  {
-    annotatable,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GetOntologyAnnotationsOptions,
+    {
+        annotatable,
+        start,
+        size,
+    }: GetOntologyAnnotationsOptions,
 ): Promise<GraphQLOntologyAnnotation[]> {
     const constraints = [];
     if (annotatable) {

--- a/src/data-sources/intermine/api/get-pathways.ts
+++ b/src/data-sources/intermine/api/get-pathways.ts
@@ -1,27 +1,27 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLGene,
-  GraphQLPathway,
-  InterminePathwayResponse,
-  interminePathwayAttributes,
-  interminePathwaySort,
-  response2pathways,
+    GraphQLGene,
+    GraphQLPathway,
+    InterminePathwayResponse,
+    interminePathwayAttributes,
+    interminePathwaySort,
+    response2pathways,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GetPathwaysOptions = {
-  gene?: GraphQLGene;
+    gene?: GraphQLGene;
 } & PaginationOptions;
 
 
 // get Pathways associated with a Gene
 export async function getPathways(
-  {
-    gene,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GetPathwaysOptions,
+    {
+        gene,
+        start,
+        size,
+    }: GetPathwaysOptions,
 ): Promise<GraphQLPathway[]> {
     const constraints = [];
     if (gene) {

--- a/src/data-sources/intermine/api/get-phylonodes.ts
+++ b/src/data-sources/intermine/api/get-phylonodes.ts
@@ -1,29 +1,29 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLPhylonode,
-  GraphQLPhylotree,
-  InterminePhylonodeResponse,
-  interminePhylonodeAttributes,
-  interminePhylonodeSort,
-  response2phylonodes,
+    GraphQLPhylonode,
+    GraphQLPhylotree,
+    InterminePhylonodeResponse,
+    interminePhylonodeAttributes,
+    interminePhylonodeSort,
+    response2phylonodes,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GetPhylonodesOptions = {
-  phylotree?: GraphQLPhylotree;
-  parent?: GraphQLPhylonode;
+    phylotree?: GraphQLPhylotree;
+    parent?: GraphQLPhylonode;
 } & PaginationOptions;
 
 
 // get Phylonodes for a Phylotree or parent Phylonode
 export async function getPhylonodes(
-  {
-    phylotree,
-    parent,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GetPhylonodesOptions,
+    {
+        phylotree,
+        parent,
+        start,
+        size,
+    }: GetPhylonodesOptions,
 ): Promise<GraphQLPhylonode[]> {
     const constraints = [];
     if (phylotree) {

--- a/src/data-sources/intermine/api/get-protein-domains.ts
+++ b/src/data-sources/intermine/api/get-protein-domains.ts
@@ -1,30 +1,30 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLGene,
-  GraphQLGeneFamily,
-  GraphQLProteinDomain,
-  IntermineProteinDomainResponse,
-  intermineProteinDomainAttributes,
-  intermineProteinDomainSort,
-  response2proteinDomains,
+    GraphQLGene,
+    GraphQLGeneFamily,
+    GraphQLProteinDomain,
+    IntermineProteinDomainResponse,
+    intermineProteinDomainAttributes,
+    intermineProteinDomainSort,
+    response2proteinDomains,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GetProteinDomainsOptions = {
-  gene?: GraphQLGene;
-  geneFamily?: GraphQLGeneFamily;
+    gene?: GraphQLGene;
+    geneFamily?: GraphQLGeneFamily;
 } & PaginationOptions;
 
 
 // get ProteinDomains for a Gene, GeneFamily
 export async function getProteinDomains(
-  {
-    gene,
-    geneFamily,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GetProteinDomainsOptions,
+    {
+        gene,
+        geneFamily,
+        start,
+        size,
+    }: GetProteinDomainsOptions,
 ): Promise<GraphQLProteinDomain[]> {
     const constraints = [];
     if (gene) {

--- a/src/data-sources/intermine/api/get-publications.ts
+++ b/src/data-sources/intermine/api/get-publications.ts
@@ -1,30 +1,30 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLAnnotatable,
-  GraphQLAuthor,
-  GraphQLPublication,
-  InterminePublicationResponse,
-  interminePublicationAttributes,
-  interminePublicationSort,
-  response2publications,
+    GraphQLAnnotatable,
+    GraphQLAuthor,
+    GraphQLPublication,
+    InterminePublicationResponse,
+    interminePublicationAttributes,
+    interminePublicationSort,
+    response2publications,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GetPublicationsOptions = {
-  author?: GraphQLAuthor;
-  annotatable?: GraphQLAnnotatable;
+    author?: GraphQLAuthor;
+    annotatable?: GraphQLAnnotatable;
 } & PaginationOptions;
 
 
 // get Publications associated with an Author or any type that extends Annotatable
 export async function getPublications(
-  {
-    author,
-    annotatable,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GetPublicationsOptions,
+    {
+        author,
+        annotatable,
+        start,
+        size,
+    }: GetPublicationsOptions,
 ): Promise<GraphQLPublication[]> {
     const constraints = [];
     if (author) {

--- a/src/data-sources/intermine/api/get-supercontig.ts
+++ b/src/data-sources/intermine/api/get-supercontig.ts
@@ -9,6 +9,7 @@ import {
 
 
 // get a Supercontig by identifier
+// does NOT throw an error if the supercontig is not found, since this happens when the identifier belongs to a chromosome
 export async function getSupercontig(identifier: string): Promise<GraphQLSupercontig> {
     const constraints = [intermineConstraint('Supercontig.primaryIdentifier', '=', identifier)];
     const query = interminePathQuery(
@@ -19,10 +20,10 @@ export async function getSupercontig(identifier: string): Promise<GraphQLSuperco
     return this.pathQuery(query)
         .then((response: IntermineSupercontigResponse) => response2supercontigs(response))
         .then((supercontigs: Array<GraphQLSupercontig>) => {
-            if (!supercontigs.length) {
-                const msg = `Supercontig with primaryIdentifier '${identifier}' not found`;
-                this.inputError(msg);
+            if (supercontigs.length) {
+                return supercontigs[0];
+            } else {
+                return null;
             }
-            return supercontigs[0];
         });
 }

--- a/src/data-sources/intermine/api/get-syntenic-regions.ts
+++ b/src/data-sources/intermine/api/get-syntenic-regions.ts
@@ -1,27 +1,27 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLSyntenicRegion,
-  GraphQLSyntenyBlock,
-  IntermineSyntenicRegionResponse,
-  intermineSyntenicRegionAttributes,
-  intermineSyntenicRegionSort,
-  response2syntenicRegions,
+    GraphQLSyntenicRegion,
+    GraphQLSyntenyBlock,
+    IntermineSyntenicRegionResponse,
+    intermineSyntenicRegionAttributes,
+    intermineSyntenicRegionSort,
+    response2syntenicRegions,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type GetSyntenicRegionsOptions = {
-  syntenyBlock?: GraphQLSyntenyBlock;
+    syntenyBlock?: GraphQLSyntenyBlock;
 } & PaginationOptions;
 
 
 // get SyntenicRegions associated with a SyntenyBlock
 export async function getSyntenicRegions(
-  {
-    syntenyBlock,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: GetSyntenicRegionsOptions,
+    {
+        syntenyBlock,
+        start,
+        size,
+    }: GetSyntenicRegionsOptions,
 ): Promise<GraphQLSyntenicRegion[]> {
     const constraints = [];
     if (syntenyBlock) {

--- a/src/data-sources/intermine/api/pagination.ts
+++ b/src/data-sources/intermine/api/pagination.ts
@@ -2,9 +2,3 @@ export type PaginationOptions = {
   start: number;
   size: number;
 };
-
-
-export const defaultPaginationOptions: PaginationOptions = {
-  start: 0,
-  size: 10,
-};

--- a/src/data-sources/intermine/api/search-expression-samples.ts
+++ b/src/data-sources/intermine/api/search-expression-samples.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLExpressionSample,
-  IntermineExpressionSampleResponse,
-  intermineExpressionSampleAttributes,
-  intermineExpressionSampleSort,
-  response2expressionSamples,
+    GraphQLExpressionSample,
+    IntermineExpressionSampleResponse,
+    intermineExpressionSampleAttributes,
+    intermineExpressionSampleSort,
+    response2expressionSamples,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchExpressionSamplesOptions = {
-  description?: string;
+    description?: string;
 } & PaginationOptions;
 
 
 // path query search for ExpressionSample by description
 export async function searchExpressionSamples(
-  {
-    description,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchExpressionSamplesOptions,
+    {
+        description,
+        start,
+        size,
+    }: SearchExpressionSamplesOptions,
 ): Promise<GraphQLExpressionSample[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-expression-sources.ts
+++ b/src/data-sources/intermine/api/search-expression-sources.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLExpressionSource,
-  IntermineExpressionSourceResponse,
-  intermineExpressionSourceAttributes,
-  intermineExpressionSourceSort,
-  response2expressionSources,
+    GraphQLExpressionSource,
+    IntermineExpressionSourceResponse,
+    intermineExpressionSourceAttributes,
+    intermineExpressionSourceSort,
+    response2expressionSources,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchExpressionSourcesOptions = {
-  description?: string;
+    description?: string;
 } & PaginationOptions;
 
 
 // path query search for ExpressionSource by description
 export async function searchExpressionSources(
-  {
-    description,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchExpressionSourcesOptions,
+    {
+        description,
+        start,
+        size,
+    }: SearchExpressionSourcesOptions,
 ): Promise<GraphQLExpressionSource[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-gene-families.ts
+++ b/src/data-sources/intermine/api/search-gene-families.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLGeneFamily,
-  IntermineGeneFamilyResponse,
-  intermineGeneFamilyAttributes,
-  intermineGeneFamilySort,
-  response2geneFamilies,
+    GraphQLGeneFamily,
+    IntermineGeneFamilyResponse,
+    intermineGeneFamilyAttributes,
+    intermineGeneFamilySort,
+    response2geneFamilies,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchGeneFamiliesOptions = {
-  description?: string;
+    description?: string;
 } & PaginationOptions;
 
 
 // path query search for GeneFamily by description
 export async function searchGeneFamilies(
-  {
-    description,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchGeneFamiliesOptions,
+    {
+        description,
+        start,
+        size,
+    }: SearchGeneFamiliesOptions,
 ): Promise<GraphQLGeneFamily[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-genes.ts
+++ b/src/data-sources/intermine/api/search-genes.ts
@@ -11,21 +11,50 @@ import { PaginationOptions } from './pagination.js';
 
 export type SearchGenesOptions = {
     description?: string;
+    genus?: string;
+    species?: string;
+    strain?: string;
+    identifier?: string;
+    name?: string;
+    geneFamilyIdentifier?: string;
 } & PaginationOptions;
 
 
-// path query search for Gene by description
+// path query search for Gene by description, etc.
 export async function searchGenes(
     {
         description,
+        genus,
+        species,
+        strain,
+        identifier,
+        name,
+        geneFamilyIdentifier,
         start,
         size,
     }: SearchGenesOptions,
 ): Promise<GraphQLGene[]> {
     const constraints = [];
     if (description) {
-        const descriptionConstraint = intermineConstraint('Gene.description', 'CONTAINS', description);
-        constraints.push(descriptionConstraint);
+        constraints.push(intermineConstraint('Gene.description', 'CONTAINS', description));
+    }
+    if (genus) {
+        constraints.push(intermineConstraint('Gene.organism.genus', '=', genus));
+    }
+    if (species) {
+        constraints.push(intermineConstraint('Gene.organism.species', '=', species));
+    }
+    if (strain) {
+        constraints.push(intermineConstraint('Gene.strain.identifier', '=', strain));
+    }
+    if (identifier) {
+        constraints.push(intermineConstraint('Gene.primaryIdentifier', 'CONTAINS', identifier));
+    }
+    if (name) {
+        constraints.push(intermineConstraint('Gene.name', 'CONTAINS', name));
+    }
+    if (geneFamilyIdentifier) {
+        constraints.push(intermineConstraint('Gene.geneFamilyAssignments.geneFamily.primaryIdentifier', 'CONTAINS', geneFamilyIdentifier));
     }
     const query = interminePathQuery(
         intermineGeneAttributes,

--- a/src/data-sources/intermine/api/search-genes.ts
+++ b/src/data-sources/intermine/api/search-genes.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLGene,
-  IntermineGeneResponse,
-  intermineGeneAttributes,
-  intermineGeneSort,
-  response2genes,
+    GraphQLGene,
+    IntermineGeneResponse,
+    intermineGeneAttributes,
+    intermineGeneSort,
+    response2genes,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchGenesOptions = {
-  description?: string;
+    description?: string;
 } & PaginationOptions;
 
 
 // path query search for Gene by description
 export async function searchGenes(
-  {
-    description,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchGenesOptions,
+    {
+        description,
+        start,
+        size,
+    }: SearchGenesOptions,
 ): Promise<GraphQLGene[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-genetic-maps.ts
+++ b/src/data-sources/intermine/api/search-genetic-maps.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLGeneticMap,
-  IntermineGeneticMapResponse,
-  intermineGeneticMapAttributes,
-  intermineGeneticMapSort,
-  response2geneticMaps,
+    GraphQLGeneticMap,
+    IntermineGeneticMapResponse,
+    intermineGeneticMapAttributes,
+    intermineGeneticMapSort,
+    response2geneticMaps,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchGeneticMapsOptions = {
-  description?: string;
+    description?: string;
 } & PaginationOptions;
 
 
 // path query search for GeneticMap by description
 export async function searchGeneticMaps(
-  {
-    description,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchGeneticMapsOptions,
+    {
+        description,
+        start,
+        size,
+    }: SearchGeneticMapsOptions,
 ): Promise<GraphQLGeneticMap[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-gwases.ts
+++ b/src/data-sources/intermine/api/search-gwases.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLGWAS,
-  IntermineGWASResponse,
-  intermineGWASAttributes,
-  intermineGWASSort,
-  response2gwas,
+    GraphQLGWAS,
+    IntermineGWASResponse,
+    intermineGWASAttributes,
+    intermineGWASSort,
+    response2gwas,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchGWASesOptions = {
-  description?: string;
+    description?: string;
 } & PaginationOptions;
 
 
 // path query search for GWAS by description
 export async function searchGWASes(
-  {
-    description,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchGWASesOptions,
+    {
+        description,
+        start,
+        size,
+    }: SearchGWASesOptions,
 ): Promise<GraphQLGWAS[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-ontology-terms.ts
+++ b/src/data-sources/intermine/api/search-ontology-terms.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLOntologyTerm,
-  IntermineOntologyTermResponse,
-  intermineOntologyTermAttributes,
-  intermineOntologyTermSort,
-  response2ontologyTerms,
+    GraphQLOntologyTerm,
+    IntermineOntologyTermResponse,
+    intermineOntologyTermAttributes,
+    intermineOntologyTermSort,
+    response2ontologyTerms,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchOntologyTermsOptions = {
-  description?: string;
+    description?: string;
 } & PaginationOptions;
 
 
 // path query search for OntologyTerm by description
 export async function searchOntologyTerms(
-  {
-    description,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchOntologyTermsOptions,
+    {
+        description,
+        start,
+        size,
+    }: SearchOntologyTermsOptions,
 ): Promise<GraphQLOntologyTerm[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-organisms.ts
+++ b/src/data-sources/intermine/api/search-organisms.ts
@@ -1,34 +1,34 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLOrganism,
-  IntermineOrganismResponse,
-  intermineOrganismAttributes,
-  intermineOrganismSort,
-  response2organisms,
+    GraphQLOrganism,
+    IntermineOrganismResponse,
+    intermineOrganismAttributes,
+    intermineOrganismSort,
+    response2organisms,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchOrganismsOptions = {
-  taxonId?: string;
-  abbreviation?: string;
-  name?: string;
-  genus?: string;
-  species?: string;
+    taxonId?: string;
+    abbreviation?: string;
+    name?: string;
+    genus?: string;
+    species?: string;
 } & PaginationOptions;
 
 
 /// path query search for Organism of a given taxonId, abbreviation, name, genus, and/or species
 export async function searchOrganisms(
-  {
-    taxonId,
-    abbreviation,
-    name,
-    genus,
-    species,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchOrganismsOptions,
+    {
+        taxonId,
+        abbreviation,
+        name,
+        genus,
+        species,
+        start,
+        size,
+    }: SearchOrganismsOptions,
 ): Promise<GraphQLOrganism[]> {
     const constraints = [];
     if (taxonId) {

--- a/src/data-sources/intermine/api/search-organisms.ts
+++ b/src/data-sources/intermine/api/search-organisms.ts
@@ -1,4 +1,4 @@
-import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
+import { intermineConstraint, intermineNotNullConstraint, interminePathQuery } from '../intermine.server.js';
 import {
     GraphQLOrganism,
     IntermineOrganismResponse,
@@ -31,25 +31,22 @@ export async function searchOrganisms(
     }: SearchOrganismsOptions,
 ): Promise<GraphQLOrganism[]> {
     const constraints = [];
+    // some organisms have null genus because they are family imports, we don't want them.
+    constraints.push(intermineNotNullConstraint('Organism.genus'));
     if (taxonId) {
-        const constraint = intermineConstraint('Organism.taxonId', '=', taxonId);
-        constraints.push(constraint);
+        constraints.push(intermineConstraint('Organism.taxonId', '=', taxonId));
     }
     if (abbreviation) {
-        const constraint = intermineConstraint('Organism.abbreviation', '=', abbreviation);
-        constraints.push(constraint);
+        constraints.push(intermineConstraint('Organism.abbreviation', '=', abbreviation));
     }
     if (name) {
-        const constraint = intermineConstraint('Organism.name', '=',  name);
-        constraints.push(constraint);
+        constraints.push(intermineConstraint('Organism.name', '=',  name));
     }
     if (genus) {
-        const constraint = intermineConstraint('Organism.genus', '=', genus);
-        constraints.push(constraint);
+        constraints.push(intermineConstraint('Organism.genus', '=', genus));
     }
     if (species) {
-        const constraint = intermineConstraint('Organism.species', '=', species);
-        constraints.push(constraint);
+        constraints.push(intermineConstraint('Organism.species', '=', species));
     }
     const query = interminePathQuery(
         intermineOrganismAttributes,

--- a/src/data-sources/intermine/api/search-protein-domains.ts
+++ b/src/data-sources/intermine/api/search-protein-domains.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLProteinDomain,
-  IntermineProteinDomainResponse,
-  intermineProteinDomainAttributes,
-  intermineProteinDomainSort,
-  response2proteinDomains,
+    GraphQLProteinDomain,
+    IntermineProteinDomainResponse,
+    intermineProteinDomainAttributes,
+    intermineProteinDomainSort,
+    response2proteinDomains,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchProteinDomainsOptions = {
-  description?: string;
+    description?: string;
 } & PaginationOptions;
 
 
 // path query search for ProteinDomain by description
 export async function searchProteinDomains(
-  {
-    description,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchProteinDomainsOptions,
+    {
+        description,
+        start,
+        size,
+    }: SearchProteinDomainsOptions,
 ): Promise<GraphQLProteinDomain[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-proteins.ts
+++ b/src/data-sources/intermine/api/search-proteins.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLProtein,
-  IntermineProteinResponse,
-  intermineProteinAttributes,
-  intermineProteinSort,
-  response2proteins,
+    GraphQLProtein,
+    IntermineProteinResponse,
+    intermineProteinAttributes,
+    intermineProteinSort,
+    response2proteins,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchProteinsOptions = {
-  description?: string;
+    description?: string;
 } & PaginationOptions;
 
 
 // path query search for Protein by description
 export async function searchProteins(
-  {
-    description,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchProteinsOptions,
+    {
+        description,
+        start,
+        size,
+    }: SearchProteinsOptions,
 ): Promise<GraphQLProtein[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-publications.ts
+++ b/src/data-sources/intermine/api/search-publications.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLPublication,
-  InterminePublicationResponse,
-  interminePublicationAttributes,
-  interminePublicationSort,
-  response2publications,
+    GraphQLPublication,
+    InterminePublicationResponse,
+    interminePublicationAttributes,
+    interminePublicationSort,
+    response2publications,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchPublicationsOptions = {
-  title?: string;
+    title?: string;
 } & PaginationOptions;
 
 
 // path query search for Publications by title
 export async function searchPublications(
-  {
-    title,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchPublicationsOptions,
+    {
+        title,
+        start,
+        size,
+    }: SearchPublicationsOptions,
 ): Promise<GraphQLPublication[]> {
     const constraints = [];
     if (title) {

--- a/src/data-sources/intermine/api/search-qtl-studies.ts
+++ b/src/data-sources/intermine/api/search-qtl-studies.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLQTLStudy,
-  IntermineQTLStudyResponse,
-  intermineQTLStudyAttributes,
-  intermineQTLStudySort,
-  response2qtlStudies,
+    GraphQLQTLStudy,
+    IntermineQTLStudyResponse,
+    intermineQTLStudyAttributes,
+    intermineQTLStudySort,
+    response2qtlStudies,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchQTLStudiesOptions = {
-  description?: string;
+    description?: string;
 } & PaginationOptions;
 
 
 // path query search for QTLStudies by description
 export async function searchQTLStudies(
-  {
-    description,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchQTLStudiesOptions,
+    {
+        description,
+        start,
+        size,
+    }: SearchQTLStudiesOptions,
 ): Promise<GraphQLQTLStudy[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-qtls.ts
+++ b/src/data-sources/intermine/api/search-qtls.ts
@@ -1,26 +1,26 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLQTL,
-  IntermineQTLResponse,
-  intermineQTLAttributes,
-  intermineQTLSort,
-  response2qtls,
+    GraphQLQTL,
+    IntermineQTLResponse,
+    intermineQTLAttributes,
+    intermineQTLSort,
+    response2qtls,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchQTLsOptions = {
-  traitName?: string;
+    traitName?: string;
 } & PaginationOptions;
 
 
 // path query search for QTLs by Trait.name
 export async function searchQTLs(
-  {
-    traitName,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchQTLsOptions,
+    {
+        traitName,
+        start,
+        size,
+    }: SearchQTLsOptions,
 ): Promise<GraphQLQTL[]> {
     const constraints = [];
     if (traitName) {

--- a/src/data-sources/intermine/api/search-strains.ts
+++ b/src/data-sources/intermine/api/search-strains.ts
@@ -12,6 +12,7 @@ import { PaginationOptions } from './pagination.js';
 export type SearchStrainsOptions = {
     description?: string;
     origin?: string;
+    species?: string;
 } & PaginationOptions;
 
 
@@ -20,18 +21,20 @@ export async function searchStrains(
     {
         description,
         origin,
+        species,
         start,
         size,
     }: SearchStrainsOptions,
 ): Promise<GraphQLStrain[]> {
     const constraints = [];
     if (description) {
-        const constraint = intermineConstraint('Strain.description', 'CONTAINS', description);
-        constraints.push(constraint);
+        constraints.push(intermineConstraint('Strain.description', 'CONTAINS', description));
     }
     if (origin) {
-        const constraint = intermineConstraint('Strain.origin', 'CONTAINS', origin);
-        constraints.push(constraint);
+        constraints.push(intermineConstraint('Strain.origin', 'CONTAINS', origin));
+    }
+    if (species) {
+        constraints.push(intermineConstraint('Strain.organism.species', '=', species));
     }
     const query = interminePathQuery(
         intermineStrainAttributes,

--- a/src/data-sources/intermine/api/search-strains.ts
+++ b/src/data-sources/intermine/api/search-strains.ts
@@ -1,28 +1,28 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLStrain,
-  IntermineStrainResponse,
-  intermineStrainAttributes,
-  intermineStrainSort,
-  response2strains,
+    GraphQLStrain,
+    IntermineStrainResponse,
+    intermineStrainAttributes,
+    intermineStrainSort,
+    response2strains,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchStrainsOptions = {
-  description?: string;
-  origin?: string;
+    description?: string;
+    origin?: string;
 } & PaginationOptions;
 
 
 // path query search for Strain by description and/or origin
 export async function searchStrains(
-  {
-    description,
-    origin,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchStrainsOptions,
+    {
+        description,
+        origin,
+        start,
+        size,
+    }: SearchStrainsOptions,
 ): Promise<GraphQLStrain[]> {
     const constraints = [];
     if (description) {

--- a/src/data-sources/intermine/api/search-traits.ts
+++ b/src/data-sources/intermine/api/search-traits.ts
@@ -1,27 +1,27 @@
 import { intermineConstraint, interminePathQuery } from '../intermine.server.js';
 import {
-  GraphQLTrait,
-  IntermineTraitResponse,
-  intermineTraitAttributes,
-  intermineTraitSort,
-  response2traits,
+    GraphQLTrait,
+    IntermineTraitResponse,
+    intermineTraitAttributes,
+    intermineTraitSort,
+    response2traits,
 } from '../models/index.js';
-import { PaginationOptions, defaultPaginationOptions } from './pagination.js';
+import { PaginationOptions } from './pagination.js';
 
 
 export type SearchTraitsOptions = {
-  name?: string;
+    name?: string;
 } & PaginationOptions;
 
 
 // path query search for Traits by name
 // NOTE: description is typically empty, as it describes the methods used to measure the trait.
 export async function searchTraits(
-  {
-    name,
-    start=defaultPaginationOptions.start,
-    size=defaultPaginationOptions.size,
-  }: SearchTraitsOptions,
+    {
+        name,
+        start,
+        size,
+    }: SearchTraitsOptions,
 ): Promise<GraphQLTrait[]> {
     const constraints = [];
     if (name) {

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -53,52 +53,56 @@ export class IntermineServer extends RESTDataSource {
     }
 
     inputError(msg: string) {
-      throw new GraphQLError(msg, {
-        extensions: {
-          code: ApolloServerErrorCode.BAD_USER_INPUT,
-        },
-      });
+        throw new GraphQLError(msg, {
+            extensions: {
+                code: ApolloServerErrorCode.BAD_USER_INPUT,
+            },
+        });
     }
 
 }
 
 
 export interface Response<I> {
-  results: Array<I>;
+    results: Array<I>;
 }
 
 
 // creates a Path Query constraint XML string
 export const intermineConstraint =
-(path: string, op: string, value: number|string): string => {
-  return `<constraint path='${path}' op='${op}' value='${value}'/>`;
-};
+    (path: string, op: string, value: number|string): string => {
+        return `<constraint path='${path}' op='${op}' value='${value}'/>`;
+    };
 
+// creates a Path Query NOT NULL constraint XML string
+export const intermineNotNullConstraint =
+    (path: string): string => {
+        return `<constraint path='${path}' op='IS NOT NULL'/>`;
+    };
 
 // creates a Path Query XML string
 export const interminePathQuery =
-(viewAttributes: Array<string>, sortBy: string, constraints: Array<string>=[]):
-string => {
-  const view = viewAttributes.join(' ');
-  const constraint = constraints.join('');
-  return `<query model='genomic' view='${view}' sortOrder='${sortBy}'>${constraint}</query>`;
-};
+    (viewAttributes: Array<string>, sortBy: string, constraints: Array<string>=[]): string => {
+        const view = viewAttributes.join(' ');
+        const constraint = constraints.join('');
+        return `<query model='genomic' view='${view}' sortOrder='${sortBy}'>${constraint}</query>`;
+    };
 
 
 // converts an InterMine result array into a GraphQL type
 export const result2graphqlObject =
-(result: IntermineModel, graphqlAttributes: Array<string>): GraphQLModel => {
-  const entries = graphqlAttributes.map((e, i) => [e, result[i]]);
-  return Object.fromEntries(entries);
-};
+    (result: IntermineModel, graphqlAttributes: Array<string>): GraphQLModel => {
+        const entries = graphqlAttributes.map((e, i) => [e, result[i]]);
+        return Object.fromEntries(entries);
+    };
 
 
 // converts an Intermine response into an array of GraphQL types
 export const response2graphqlObjects =
-<I extends IntermineModel>
-(response: Response<I>, graphqlAttributes: Array<string>):
+    <I extends IntermineModel>
+    (response: Response<I>, graphqlAttributes: Array<string>):
 Array<GraphQLModel> => {
-  return response.results.map(
-      (result: I) => result2graphqlObject(result, graphqlAttributes)
-  );
-};
+        return response.results.map(
+            (result: I) => result2graphqlObject(result, graphqlAttributes)
+        );
+    };

--- a/src/data-sources/intermine/models/gene-family-assignment.ts
+++ b/src/data-sources/intermine/models/gene-family-assignment.ts
@@ -20,7 +20,7 @@ export type IntermineGeneFamilyAssignment = [
   number,
   number,
   number,
-  number,
+  string,
 ];
 
 

--- a/src/data-sources/intermine/models/organism.ts
+++ b/src/data-sources/intermine/models/organism.ts
@@ -24,7 +24,7 @@ export const intermineOrganismAttributes = [
     'Organism.species',
     'Organism.shortName',
 ];
-export const intermineOrganismSort = 'Organism.taxonId'; // guaranteed not null
+export const intermineOrganismSort = 'Organism.genus'; // guaranteed not null
 export type IntermineOrganism = [
   number,
   string,

--- a/src/resolvers/intermine/gene-family-assignment.ts
+++ b/src/resolvers/intermine/gene-family-assignment.ts
@@ -10,7 +10,7 @@ export const geneFamilyAssignmentFactory = (sourceName: keyof DataSources): Reso
     },
     GeneFamilyAssignment: {
         geneFamily: async(geneFamilyAssignment, _, { dataSources }) => {
-            return dataSources[sourceName].getGeneFamily(geneFamilyAssignment.geneFamilyId);
+            return dataSources[sourceName].getGeneFamily(geneFamilyAssignment.geneFamilyIdentifier);
         },
     },
 });

--- a/src/resolvers/intermine/gene.ts
+++ b/src/resolvers/intermine/gene.ts
@@ -7,8 +7,8 @@ export const geneFactory = (sourceName: keyof DataSources): ResolverMap => ({
         gene: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getGene(identifier);
         },
-        genes: async (_, { description, start, size }, { dataSources }) => {
-            const args = {description, start, size};
+        genes: async (_, { description, genus, species, strain, identifier, name, geneFamilyIdentifier, start, size }, { dataSources }) => {
+            const args = {description, genus, species, strain, identifier, name, geneFamilyIdentifier, start, size};
             return dataSources[sourceName].searchGenes(args);
         },
     },

--- a/src/resolvers/intermine/strain.ts
+++ b/src/resolvers/intermine/strain.ts
@@ -7,8 +7,8 @@ export const strainFactory = (sourceName: keyof DataSources): ResolverMap => ({
         strain: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getStrain(identifier);
         },
-        strains: async (_, { description, origin, start, size }, { dataSources }) => {
-            const args = {description, origin, start, size};
+        strains: async (_, { description, origin, species, start, size }, { dataSources }) => {
+            const args = {description, origin, species, start, size};
             return dataSources[sourceName].searchStrains(args);
         },
     },

--- a/src/types/Query.graphql
+++ b/src/types/Query.graphql
@@ -47,7 +47,7 @@ type Query {
   ### multiple-result queries (typically searches)
   expressionSamples(description: String, start: Int, size: Int): [ExpressionSample]
   expressionSources(description: String, start: Int, size: Int): [ExpressionSource]
-  genes(description: String, start: Int, size: Int): [Gene]
+  genes(description: String, genus: String, species: String, strain: String, identifier: String, name: String, geneFamilyIdentifier: String, start: Int, size: Int): [Gene]
   geneFamilies(description: String, start: Int, size: Int): [GeneFamily]
   geneticMaps(description: String, start: Int, size: Int): [GeneticMap]
   gwases(description: String, start: Int, size: Int): [GWAS]
@@ -58,7 +58,7 @@ type Query {
   publications(title: String, start: Int, size: Int): [Publication]
   qtls(traitName: String, start: Int, size: Int): [QTL]
   qtlStudies(description: String, start: Int, size: Int): [ProteinDomain]
-  strains(description: String, origin: String, start: Int, size: Int): [Strain]
+  strains(description: String, origin: String, species: String, start: Int, size: Int): [Strain]
   traits(name: String, start: Int, size: Int): [Trait]
 
   ### no-parameter queries


### PR DESCRIPTION
This removes defaultPaginationsOptions throughout, allowing start and size to be null. This work fine in returning all records in testing with the Apollo sandbox with start and size left null.

This update was done against the main branch and should be merged there. This will fix the limited population of the selectors in the gene search component after I merge them put into the gene-search-parameters branch.

NOTE: this will lead to many many returned records for many queries if size is not supplied! Which is what we want. Supply start and size unless you want all of the records returned!