### PR TITLE
Add linkouts microservice to GraphQL API

### DIFF
--- a/src/data-sources/index.ts
+++ b/src/data-sources/index.ts
@@ -1,10 +1,16 @@
 import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
 
 import { IntermineAPI } from './intermine/index.js';
+import { MicroservicesAPI } from './microservices/index.js';
+
+
+export { IntermineAPI } from './intermine/index.js';
+export { MicroservicesAPI } from './microservices/index.js';
 
 
 export type DataSources = {
   lisIntermineAPI: IntermineAPI;
+  lisMicroservicesAPI: MicroservicesAPI;
 };
 
 
@@ -12,5 +18,6 @@ export const dataSources = (cache: KeyValueCache): DataSources => {
   const config = {cache};
   return {
     lisIntermineAPI: new IntermineAPI('https://mines.legumeinfo.org/minimine/service', config),
+    lisMicroservicesAPI: new MicroservicesAPI('https://linkouts.services.legumeinfo.org', config),
   };
 };

--- a/src/data-sources/microservices/index.ts
+++ b/src/data-sources/microservices/index.ts
@@ -1,0 +1,1 @@
+export * from './microservices.api.js';

--- a/src/data-sources/microservices/microservices.api.ts
+++ b/src/data-sources/microservices/microservices.api.ts
@@ -1,0 +1,49 @@
+import { DataSourceConfig, RESTDataSource } from '@apollo/datasource-rest';
+
+import { GraphQLLinkout } from './models/index.js';
+
+
+export class MicroservicesAPI extends RESTDataSource {
+
+    constructor(baseURL: string, config: DataSourceConfig={}) {
+        super(config);
+        // set the URL all requests will be sent to
+        this.baseURL = baseURL;
+        // NOTE: RESTDataSource uses the Web API URL interface to add paths to
+        // the end of the baseURL. If the baseURL already ends with a path then
+        // the path will be overridden with the path provided by RESTDataSource
+        // unless the baseURL ends with a '/'. Furthermore, adding a path that
+        // starts with a '/' to baseURL will always override whatever path
+        // baseURL already ends with, so here we make sure baseURL ends with a
+        // '/' and note that none of the request paths in this class should
+        // start with a '/'.
+        if (!this.baseURL.endsWith('/')) {
+            this.baseURL += '/';
+        }
+    }
+
+    async getLinkoutsForGene(identifier: string): Promise<GraphQLLinkout[]> {
+        const options = {
+            headers: {
+              'Content-Type': 'application/json',
+              'Accept': 'application/json',
+            },
+            body: JSON.stringify({genes: [identifier]}),
+        };
+        return await this.post('gene_linkouts', options);
+    }
+
+    async getLinkoutsForLocation(identifier: string, start: number, end: number):
+    Promise<GraphQLLinkout[]> {
+        const region = `${identifier}:${start}-${end}`;
+        const options = {
+            headers: {
+              'Content-Type': 'application/json',
+              'Accept': 'application/json',
+            },
+            body: JSON.stringify({genomic_regions: [region]}),
+        };
+        return await this.post('genomic_region_linkouts', options);
+    }
+
+}

--- a/src/data-sources/microservices/models/index.ts
+++ b/src/data-sources/microservices/models/index.ts
@@ -1,0 +1,1 @@
+export * from './linkout.js';

--- a/src/data-sources/microservices/models/linkout.ts
+++ b/src/data-sources/microservices/models/linkout.ts
@@ -1,0 +1,4 @@
+export type GraphQLLinkout = {
+  'href': string,
+  'text': string,
+};

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,9 +1,11 @@
 import { mergeResolvers } from '@graphql-tools/merge';
 import { intermineResolverFactory } from './intermine/index.js';
+import { microservicesResolverFactory } from './microservices/index.js';
 
 
 export const resolvers = mergeResolvers([
-  intermineResolverFactory('lisIntermineAPI'),
+  intermineResolverFactory('lisIntermineAPI', 'lisMicroservicesAPI'),
+  microservicesResolverFactory('lisMicroservicesAPI'),
   // add more resolvers here
   // NOTE: you can't use mergeResolvers with multiple intermine resolvers; you'll
   // have to implement an aggregate resolver so they don't overwrite each other

--- a/src/resolvers/intermine/author.ts
+++ b/src/resolvers/intermine/author.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const authorFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const authorFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         author: async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getAuthor(id);

--- a/src/resolvers/intermine/chromosome.ts
+++ b/src/resolvers/intermine/chromosome.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const chromosomeFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const chromosomeFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         chromosome: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getChromosome(identifier);

--- a/src/resolvers/intermine/data-set.ts
+++ b/src/resolvers/intermine/data-set.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const dataSetFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const dataSetFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         dataSet: async (_, { name }, { dataSources }) => {
             return dataSources[sourceName].getDataSet(name);

--- a/src/resolvers/intermine/expression-sample.ts
+++ b/src/resolvers/intermine/expression-sample.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const expressionSampleFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const expressionSampleFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         expressionSample:  async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getExpressionSample(identifier);

--- a/src/resolvers/intermine/expression-source.ts
+++ b/src/resolvers/intermine/expression-source.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const expressionSourceFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const expressionSourceFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         expressionSource:  async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getExpressionSource(identifier);

--- a/src/resolvers/intermine/gene-family-assignment.ts
+++ b/src/resolvers/intermine/gene-family-assignment.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const geneFamilyAssignmentFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const geneFamilyAssignmentFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         geneFamilyAssignment: async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getGeneFamilyAssignment(id);

--- a/src/resolvers/intermine/gene-family-tally.ts
+++ b/src/resolvers/intermine/gene-family-tally.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const geneFamilyTallyFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const geneFamilyTallyFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         geneFamilyTally: async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getGeneFamilyTally(id);

--- a/src/resolvers/intermine/gene-family.ts
+++ b/src/resolvers/intermine/gene-family.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const geneFamilyFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const geneFamilyFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         geneFamily: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getGeneFamily(identifier);

--- a/src/resolvers/intermine/gene.ts
+++ b/src/resolvers/intermine/gene.ts
@@ -1,8 +1,14 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI, MicroservicesAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const geneFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const geneFactory =
+(
+    sourceName: KeyOfType<DataSources, IntermineAPI>,
+    microservicesSource: KeyOfType<DataSources, MicroservicesAPI>,
+):
+ResolverMap => ({
     Query: {
         gene: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getGene(identifier);
@@ -46,6 +52,10 @@ export const geneFactory = (sourceName: keyof DataSources): ResolverMap => ({
         publications: async (gene, { start, size }, { dataSources }) => {
             const args = {annotatable: gene, start, size};
             return dataSources[sourceName].getPublications(args);
+        },
+        linkouts: async (gene, _, { dataSources }) => {
+          const {identifier} = gene;
+          return dataSources[microservicesSource].getLinkoutsForGene(identifier);
         },
     },
 });

--- a/src/resolvers/intermine/gene.ts
+++ b/src/resolvers/intermine/gene.ts
@@ -7,8 +7,7 @@ export const geneFactory =
 (
     sourceName: KeyOfType<DataSources, IntermineAPI>,
     microservicesSource: KeyOfType<DataSources, MicroservicesAPI>,
-):
-ResolverMap => ({
+): ResolverMap => ({
     Query: {
         gene: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getGene(identifier);

--- a/src/resolvers/intermine/genetic-map.ts
+++ b/src/resolvers/intermine/genetic-map.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const geneticMapFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const geneticMapFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         geneticMap:  async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getGeneticMap(identifier);

--- a/src/resolvers/intermine/genetic-marker.ts
+++ b/src/resolvers/intermine/genetic-marker.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const geneticMarkerFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const geneticMarkerFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         geneticMarker:  async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getGeneticMarker(identifier);

--- a/src/resolvers/intermine/gwas-result.ts
+++ b/src/resolvers/intermine/gwas-result.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const gwasResultFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const gwasResultFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         gwasResult: async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getGWASResult(id);

--- a/src/resolvers/intermine/gwas.ts
+++ b/src/resolvers/intermine/gwas.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const gwasFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const gwasFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         gwas: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getGWAS(identifier);

--- a/src/resolvers/intermine/index.ts
+++ b/src/resolvers/intermine/index.ts
@@ -2,7 +2,8 @@
 
 import { mergeResolvers } from '@graphql-tools/merge';
 
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI, MicroservicesAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 
 import { authorFactory } from './author.js';
 import { chromosomeFactory } from './chromosome.js';
@@ -84,9 +85,13 @@ const factories = [
 // data source.
 // TODO: our resolver type returned by the factories doesn't match the type
 // expected by mergeResolvers
-export const intermineResolverFactory = (sourceName: keyof DataSources) => {
+export const intermineResolverFactory =
+(
+    sourceName: KeyOfType<DataSources, IntermineAPI>,
+    microservicesSource: KeyOfType<DataSources, MicroservicesAPI>,
+) => {
     const sourceResolvers = factories.map((factory) => {
-        return factory(sourceName);
+        return factory(sourceName, microservicesSource);
     });
     return mergeResolvers(sourceResolvers);
 };

--- a/src/resolvers/intermine/linkage-group-position.ts
+++ b/src/resolvers/intermine/linkage-group-position.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const linkageGroupPositionFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const linkageGroupPositionFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         linkageGroupPosition:  async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getLinkageGroupPosition(id);

--- a/src/resolvers/intermine/linkage-group.ts
+++ b/src/resolvers/intermine/linkage-group.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const linkageGroupFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const linkageGroupFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         linkageGroup:  async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getLinkageGroup(id);

--- a/src/resolvers/intermine/location.ts
+++ b/src/resolvers/intermine/location.ts
@@ -1,8 +1,13 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI, MicroservicesAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const locationFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const locationFactory =
+(
+    sourceName: KeyOfType<DataSources, IntermineAPI>,
+    microservicesSource: KeyOfType<DataSources, MicroservicesAPI>,
+): ResolverMap => ({
     Query: {
         location: async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getLocation(id);
@@ -19,6 +24,10 @@ export const locationFactory = (sourceName: keyof DataSources): ResolverMap => (
         dataSets: async (location, { start, size }, { dataSources }) => {
             const args = {start, size};
             return dataSources[sourceName].getDataSetsForLocation(location, args);
+        },
+        linkouts: async (location, _, { dataSources }) => {
+          const {locatedOnIdentifier, start, end} = location;
+          return dataSources[microservicesSource].getLinkoutsForLocation(locatedOnIdentifier, start, end);
         },
     },
 });

--- a/src/resolvers/intermine/mine-web-properties.ts
+++ b/src/resolvers/intermine/mine-web-properties.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const mineWebPropertiesFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const mineWebPropertiesFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         mineWebProperties: async (_, __, { dataSources }) => {
             return dataSources[sourceName].getMineWebProperties();

--- a/src/resolvers/intermine/mrna.ts
+++ b/src/resolvers/intermine/mrna.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const mRNAFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const mRNAFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         mRNA: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getMRNA(identifier);

--- a/src/resolvers/intermine/ontology-annotation.ts
+++ b/src/resolvers/intermine/ontology-annotation.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const ontologyAnnotationFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const ontologyAnnotationFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         ontologyAnnotation: async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getOntologyAnnotation(id);

--- a/src/resolvers/intermine/ontology-term.ts
+++ b/src/resolvers/intermine/ontology-term.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const ontologyTermFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const ontologyTermFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         ontologyTerm: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getOntologyTerm(identifier);

--- a/src/resolvers/intermine/ontology.ts
+++ b/src/resolvers/intermine/ontology.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const ontologyFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const ontologyFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         ontology: async (_, { name }, { dataSources }) => {
             return dataSources[sourceName].getOntology(name);

--- a/src/resolvers/intermine/organism.ts
+++ b/src/resolvers/intermine/organism.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const organismFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const organismFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         organism: async (_, { taxonId }, { dataSources }) => {
             return dataSources[sourceName].getOrganism(taxonId);

--- a/src/resolvers/intermine/pathway.ts
+++ b/src/resolvers/intermine/pathway.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const pathwayFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const pathwayFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         pathway: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getPathway(identifier);

--- a/src/resolvers/intermine/phylonode.ts
+++ b/src/resolvers/intermine/phylonode.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const phylonodeFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const phylonodeFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         phylonode: async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getPhylonode(id);

--- a/src/resolvers/intermine/phylotree.ts
+++ b/src/resolvers/intermine/phylotree.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const phylotreeFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const phylotreeFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         phylotree: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getPhylotree(identifier);

--- a/src/resolvers/intermine/protein-domain.ts
+++ b/src/resolvers/intermine/protein-domain.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const proteinDomainFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const proteinDomainFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         proteinDomain: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getProteinDomain(identifier);

--- a/src/resolvers/intermine/protein.ts
+++ b/src/resolvers/intermine/protein.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const proteinFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const proteinFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         protein: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getProtein(identifier);

--- a/src/resolvers/intermine/publication.ts
+++ b/src/resolvers/intermine/publication.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const publicationFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const publicationFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         publication: async (_, { doi }, { dataSources }) => {
             return dataSources[sourceName].getPublication(doi);

--- a/src/resolvers/intermine/qtl-study.ts
+++ b/src/resolvers/intermine/qtl-study.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const qtlStudyFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const qtlStudyFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         qtlStudy:  async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getQTLStudy(identifier);

--- a/src/resolvers/intermine/qtl.ts
+++ b/src/resolvers/intermine/qtl.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const qtlFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const qtlFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         qtl:  async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getQTL(id);

--- a/src/resolvers/intermine/strain.ts
+++ b/src/resolvers/intermine/strain.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const strainFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const strainFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         strain: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getStrain(identifier);

--- a/src/resolvers/intermine/supercontig.ts
+++ b/src/resolvers/intermine/supercontig.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const supercontigFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const supercontigFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         supercontig: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getSupercontig(identifier);

--- a/src/resolvers/intermine/syntenic-region.ts
+++ b/src/resolvers/intermine/syntenic-region.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const syntenicRegionFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const syntenicRegionFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         syntenicRegion: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getSyntenicRegion(identifier);

--- a/src/resolvers/intermine/synteny-block.ts
+++ b/src/resolvers/intermine/synteny-block.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const syntenyBlockFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const syntenyBlockFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         syntenyBlock: async (_, { id }, { dataSources }) => {
             return dataSources[sourceName].getSyntenyBlock(id);

--- a/src/resolvers/intermine/trait.ts
+++ b/src/resolvers/intermine/trait.ts
@@ -1,8 +1,10 @@
-import { DataSources } from '../../data-sources/index.js';
+import { DataSources, IntermineAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
 
 
-export const traitFactory = (sourceName: keyof DataSources): ResolverMap => ({
+export const traitFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
+ResolverMap => ({
     Query: {
         trait: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getTrait(identifier);

--- a/src/resolvers/microservices/index.ts
+++ b/src/resolvers/microservices/index.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+
+import { mergeResolvers } from '@graphql-tools/merge';
+
+import { DataSources, MicroservicesAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
+ './linkage-group.js';
+
+import { linkoutsFactory } from './linkouts.js';
+
+
+const factories = [
+    linkoutsFactory,
+];
+
+
+// a factory function that generates resolvers for a specific microservices deployment.
+// TODO: our resolver type returned by the factories doesn't match the type
+// expected by mergeResolvers
+export const microservicesResolverFactory = (sourceName: KeyOfType<DataSources, MicroservicesAPI>) => {
+    const sourceResolvers = factories.map((factory) => {
+        return factory(sourceName);
+    });
+    return mergeResolvers(sourceResolvers);
+};

--- a/src/resolvers/microservices/index.ts
+++ b/src/resolvers/microservices/index.ts
@@ -4,7 +4,6 @@ import { mergeResolvers } from '@graphql-tools/merge';
 
 import { DataSources, MicroservicesAPI } from '../../data-sources/index.js';
 import { KeyOfType } from '../../utils/index.js';
- './linkage-group.js';
 
 import { linkoutsFactory } from './linkouts.js';
 

--- a/src/resolvers/microservices/linkouts.ts
+++ b/src/resolvers/microservices/linkouts.ts
@@ -1,0 +1,16 @@
+import { DataSources, MicroservicesAPI } from '../../data-sources/index.js';
+import { KeyOfType } from '../../utils/index.js';
+import { ResolverMap } from '../resolver.js';
+
+
+export const linkoutsFactory = (sourceName: KeyOfType<DataSources, MicroservicesAPI>):
+ResolverMap => ({
+    Query: {
+        geneLinkout: async (_, { identifier }, { dataSources }) => {
+            return dataSources[sourceName].getLinkoutsForGene(identifier);
+        },
+        locationLinkout: async (_, { identifier, start, end }, { dataSources }) => {
+            return dataSources[sourceName].getLinkoutsForLocation(identifier, start, end);
+        },
+    },
+});

--- a/src/resolvers/microservices/linkouts.ts
+++ b/src/resolvers/microservices/linkouts.ts
@@ -6,10 +6,10 @@ import { ResolverMap } from '../resolver.js';
 export const linkoutsFactory = (sourceName: KeyOfType<DataSources, MicroservicesAPI>):
 ResolverMap => ({
     Query: {
-        geneLinkout: async (_, { identifier }, { dataSources }) => {
+        geneLinkouts: async (_, { identifier }, { dataSources }) => {
             return dataSources[sourceName].getLinkoutsForGene(identifier);
         },
-        locationLinkout: async (_, { identifier, start, end }, { dataSources }) => {
+        locationLinkouts: async (_, { identifier, start, end }, { dataSources }) => {
             return dataSources[sourceName].getLinkoutsForLocation(identifier, start, end);
         },
     },

--- a/src/types/Gene.graphql
+++ b/src/types/Gene.graphql
@@ -60,4 +60,5 @@ type Gene implements SequenceFeature {
   pathways: [Pathway]
   # regulatoryRegions
   # UTRs
+  linkouts: [Linkout]
 }

--- a/src/types/Linkout.graphql
+++ b/src/types/Linkout.graphql
@@ -1,0 +1,4 @@
+type Linkout {
+  href: String!
+  text: String!
+}

--- a/src/types/Location.graphql
+++ b/src/types/Location.graphql
@@ -16,4 +16,5 @@ type Location {
   supercontig: Supercontig
   # feature
   dataSets: [DataSet]
+  linkouts: [Linkout]
 }

--- a/src/types/Query.graphql
+++ b/src/types/Query.graphql
@@ -65,6 +65,6 @@ type Query {
   mineWebProperties: MineWebProperties
 
   ### microservices queries
-  geneLinkout(identifier: String!): [Linkout!]!
-  locationLinkout(identifier: ID!, start: Int!, end: Int!): [Linkout!]!
+  geneLinkouts(identifier: String!): [Linkout!]!
+  locationLinkouts(identifier: ID!, start: Int!, end: Int!): [Linkout!]!
 }

--- a/src/types/Query.graphql
+++ b/src/types/Query.graphql
@@ -64,4 +64,7 @@ type Query {
   ### no-parameter queries
   mineWebProperties: MineWebProperties
 
+  ### microservices queries
+  geneLinkout(identifier: String!): [Linkout!]!
+  locationLinkout(identifier: ID!, start: Int!, end: Int!): [Linkout!]!
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './key-of-type.js';

--- a/src/utils/key-of-type.ts
+++ b/src/utils/key-of-type.ts
@@ -1,0 +1,3 @@
+export type KeyOfType<T, V> = keyof {
+  [P in keyof T as T[P] extends V? P: never]: any
+}


### PR DESCRIPTION
A `MicroservicesAPI` data source class was added with two API methods for the linkouts microservice: `getLinkoutsForGene` and `getLinkoutsForLocation`. Unlike the linkout microservice, these endpoints are singular instead of plural due to limitations of the GraphQL API, i.e. the formatted string the microservice uses for each location was broken into multiple GraphQL resolver parameters, which makes it non-trivial to query for multiple locations.