### PR TITLE
Fixed the linkout resolvers to return the correct results structure.

### DIFF
--- a/src/resolvers/microservices/linkouts.ts
+++ b/src/resolvers/microservices/linkouts.ts
@@ -7,10 +7,12 @@ export const linkoutsFactory = (sourceName: KeyOfType<DataSources, Microservices
 ResolverMap => ({
     Query: {
         geneLinkouts: async (_, { identifier }, { dataSources }) => {
-            return dataSources[sourceName].getLinkoutsForGene(identifier);
+            return dataSources[sourceName].getLinkoutsForGene(identifier)
+              .then((results) => ({results}));
         },
         locationLinkouts: async (_, { identifier, start, end }, { dataSources }) => {
-            return dataSources[sourceName].getLinkoutsForLocation(identifier, start, end);
+            return dataSources[sourceName].getLinkoutsForLocation(identifier, start, end)
+              .then((results) => ({results}));
         },
     },
 });


### PR DESCRIPTION
This should've been included in the big PR that updated all entrypoint fields to use a `results` field, but it somehow got missed!