### PR TITLE
The pageInfo pageCount now returns 1 if no results were found.

### DIFF
--- a/src/models/page-info.ts
+++ b/src/models/page-info.ts
@@ -12,7 +12,7 @@ export const pageInfoFactory =
   (numResults: number, currentPage: number|null, pageSize: number|null) => {
     if (currentPage == null) currentPage = 1;
     if (pageSize == null) pageSize = numResults;
-    const pageCount = Math.ceil(numResults/pageSize);
+    const pageCount = (numResults == 0 ? 1 : Math.ceil(numResults/pageSize));
     return {
       currentPage,
       pageSize,


### PR DESCRIPTION
Previously it tried to compute the size by dividing by the number of results, which threw an error since you can't divide by 0.