### PR TITLE
Remove identifier from GWASResult. (Was mistakenly coded Annotatable.)

### DIFF
--- a/src/data-sources/intermine/models/gwas-result.ts
+++ b/src/data-sources/intermine/models/gwas-result.ts
@@ -1,57 +1,51 @@
 import { IntermineDataResponse, response2graphqlObjects } from '../intermine.server.js';
 
-
-// <class name="GWASResult" is-interface="true" term="">
-// 	<attribute name="pValue" type="java.lang.Double"/>
-//      <attribute name="markerName" type="java.lang.String"/>
-// 	<reference name="gwas" referenced-type="GWAS" reverse-reference="results"/>
-// 	<reference name="trait" referenced-type="Trait" reverse-reference="gwasResults"/>
-// 	<reference name="dataSet" referenced-type="DataSet"/>
-// 	<collection name="markers" referenced-type="GeneticMarker" reverse-reference="gwasResults"/>
+// <class name="GWASResult" is-interface="true">
+//   <attribute name="markerName" type="java.lang.String"/>
+//   <attribute name="pValue" type="java.lang.Double"/>
+//   <reference name="gwas" referenced-type="GWAS" reverse-reference="results"/>
+//   <reference name="trait" referenced-type="Trait" reverse-reference="gwasResults"/>
+//   <collection name="markers" referenced-type="GeneticMarker" reverse-reference="gwasResults"/>
+//   <reference name="dataSet" referenced-type="DataSet"/>
 // </class>
 export const intermineGWASResultAttributes = [
     'GWASResult.id',
-    'GWASResult.identifier',
-    'GWASResult.pValue',
     'GWASResult.markerName',
+    'GWASResult.pValue',
     'GWASResult.gwas.primaryIdentifier',
     'GWASResult.trait.primaryIdentifier',
     'GWASResult.dataSet.name',
 ];
 export const intermineGWASResultSort = 'GWASResult.markerName';
 export type IntermineGWASResult = [
-  number,
-  number,
-  number,
-  string,
-  string,
-  string,
-  string,
+    number,
+    string,
+    number,
+    string,
+    string,
+    string,
 ];
-
 
 // type GWASResult {
 //   id: ID!
-//   pValue: Float
-//   markerName: String
-//   # gwas: GWAS
-//   trait: Trait
-//   dataSet
-//   # markers
+//   markerName: String!
+//   pValue: Float!
+//   gwas: GWAS!
+//   trait: Trait!
+//   markers: [GeneticMarker]
+//   dataSet: DataSet!
 // }
 export const graphqlGWASResultAttributes = [
     'id',
-    'identifier',
-    'pValue',
     'markerName',
+    'pValue',
     'gwasIdentifier',
     'traitIdentifier',
     'dataSetName',
 ];
 export type GraphQLGWASResult = {
-  [prop in typeof graphqlGWASResultAttributes[number]]: string;
+    [prop in typeof graphqlGWASResultAttributes[number]]: string;
 }
-
 
 export type IntermineGWASResultResponse = IntermineDataResponse<IntermineGWASResult>;
 export function response2gwasResults(response: IntermineGWASResultResponse): Array<GraphQLGWASResult> {

--- a/src/resolvers/intermine/gwas-result.ts
+++ b/src/resolvers/intermine/gwas-result.ts
@@ -1,7 +1,6 @@
 import { DataSources, IntermineAPI } from '../../data-sources/index.js';
 import { inputError, KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
-import { annotatableFactory } from './annotatable.js';
 
 
 export const gwasResultFactory = (sourceName: KeyOfType<DataSources, IntermineAPI>):
@@ -17,7 +16,6 @@ ResolverMap => ({
         },
     },
     GWASResult: {
-        ...annotatableFactory(sourceName),
         gwas: async(gwasResult, _, { dataSources }) => {
             return dataSources[sourceName].getGWAS(gwasResult.gwasIdentifier)
                 // @ts-ignore: implicit type any error

--- a/src/types/GWASResult.graphql
+++ b/src/types/GWASResult.graphql
@@ -1,22 +1,17 @@
-# <class name="GWASResult" is-interface="true" term="">
-# 	<attribute name="pValue" type="java.lang.Double"/>
-# 	<attribute name="markerName" type="java.lang.String"/>
-# 	<reference name="gwas" referenced-type="GWAS" reverse-reference="results"/>
-# 	<reference name="trait" referenced-type="Trait" reverse-reference="gwasResults"/>
-# 	<reference name="dataSet" referenced-type="DataSet"/>
-# 	<collection name="markers" referenced-type="GeneticMarker" reverse-reference="gwasResults"/>
+# <class name="GWASResult" is-interface="true">
+#   <attribute name="markerName" type="java.lang.String"/>
+#   <attribute name="pValue" type="java.lang.Double"/>
+#   <reference name="gwas" referenced-type="GWAS" reverse-reference="results"/>
+#   <reference name="trait" referenced-type="Trait" reverse-reference="gwasResults"/>
+#   <collection name="markers" referenced-type="GeneticMarker" reverse-reference="gwasResults"/>
+#   <reference name="dataSet" referenced-type="DataSet"/>
 # </class>
-type GWASResult implements Annotatable {
-  # Annotatable
+type GWASResult {
   id: ID!
-  identifier: ID!
-  ontologyAnnotations: [OntologyAnnotation!]!
-  publications: [Publication!]!
-  # GWASResult
-  pValue: Float
-  markerName: String
-  gwas: GWAS
-  trait: Trait
-  dataSet: DataSet
-  # markers
+  markerName: String!
+  pValue: Float!
+  gwas: GWAS!
+  trait: Trait!
+  markers: [GeneticMarker]
+  dataSet: DataSet!
 }


### PR DESCRIPTION
As far as I can tell, GWASResult was the only type that was incorrectly coded as Annotatable. Trait queries now work with GWASResult types included.

@That-Thing please use the fix-gwasresult branch to test and approve this update. If you find any other errors, post 'em here and I'll hit them in this commit.