### PR TITLE
Add a release checklist issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -8,11 +8,11 @@ assignees: ''
 ---
 
 - [ ] Create a branch for the release
-- [ ] Update the dependencies. The dependabot PR backlog is not comprehensive and doesn't include transitive dependencies, and merging them one at a time tends to break things, so the best way to do this is manually with npm in a separate branch.
-- [ ] Bump the intermineVersion in `data-sources/intermine/api/index.ts` if appropriate.
+- [ ] Update the dependencies. The dependabot PR backlog is not comprehensive and doesn't include transitive dependencies, and merging them one at a time tends to break things, so the best way to do this is manually with npm.
+- [ ] Bump the `intermineVersion` in `data-sources/intermine/api/index.ts` if appropriate.
 - [ ] Update the base image version in the `Dockerfile` if necessary (this should be the most recent node LTS version) and do a test build and run of the Docker image on you local machine so you know if something is going to go off the rails before the automated build action on GitHub.
 - [ ] Update the GHCR image tag in `compose.prod.yml` to the imminent release version
-- [ ] Bump the version number in `package.json`.
+- [ ] Bump the `"version"` number in `package.json`.
 - [ ] Open a PR that merges the release branch into main.
-- [ ] Merge the release PR after is passes testing and review.
+- [ ] Merge the release PR after it passes testing and review.
 - [ ] Tag a corresponding release on GitHub. This will trigger an automated Docker image build on GitHub. If the build succeeds it will be automatically published to GHCR.

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,0 +1,18 @@
+---
+name: Release Checklist
+about: A checklist of tasks required to make a release
+title: Release MAJOR.MINOR.PATCH
+labels: release
+assignees: ''
+
+---
+
+- [ ] Create a branch for the release
+- [ ] Update the dependencies. The dependabot PR backlog is not comprehensive and doesn't include transitive dependencies, and merging them one at a time tends to break things, so the best way to do this is manually with npm in a separate branch.
+- [ ] Bump the intermineVersion in `data-sources/intermine/api/index.ts` if appropriate.
+- [ ] Update the base image version in the `Dockerfile` if necessary (this should be the most recent node LTS version) and do a test build and run of the Docker image on you local machine so you know if something is going to go off the rails before the automated build action on GitHub.
+- [ ] Update the GHCR image tag in `compose.prod.yml` to the imminent release version
+- [ ] Bump the version number in `package.json`.
+- [ ] Open a PR that merges the release branch into main.
+- [ ] Merge the release PR after is passes testing and review.
+- [ ] Tag a corresponding release on GitHub. This will trigger an automated Docker image build on GitHub. If the build succeeds it will be automatically published to GHCR.


### PR DESCRIPTION
The release checklist is an issue template instead of a PR template because the GitHub UI supports selecting what template you want to use for an issue but not for a PR. Also I think it makes more sense to complete the checklist prior to opening a PR so this helps you keep track of things before you're ready to open a PR.