### PR TITLE
Added panGeneSetIdentifier as a parameter to searchGenes.

### DIFF
--- a/src/data-sources/intermine/api/search-genes.ts
+++ b/src/data-sources/intermine/api/search-genes.ts
@@ -23,6 +23,7 @@ export type SearchGenesOptions = {
     identifier?: string;
     name?: string;
     geneFamilyIdentifier?: string;
+    panGeneSetIdentifier?: string;
 } & PaginationOptions;
 
 
@@ -36,6 +37,7 @@ export async function searchGenes(
         identifier,
         name,
         geneFamilyIdentifier,
+        panGeneSetIdentifier,
         page,
         pageSize,
     }: SearchGenesOptions,
@@ -62,6 +64,9 @@ export async function searchGenes(
     }
     if (geneFamilyIdentifier) {
         constraints.push(intermineConstraint('Gene.geneFamilyAssignments.geneFamily.primaryIdentifier', 'CONTAINS', geneFamilyIdentifier));
+    }
+    if (panGeneSetIdentifier) {
+        constraints.push(intermineConstraint('Gene.panGeneSets.primaryIdentifier', 'CONTAINS', panGeneSetIdentifier));
     }
     const query = interminePathQuery(
         intermineGeneAttributes,

--- a/src/resolvers/intermine/gene.ts
+++ b/src/resolvers/intermine/gene.ts
@@ -18,8 +18,8 @@ export const geneFactory =
                 }
                 return {results: gene};
             },
-            genes: async (_, { description, genus, species, strain, identifier, name, geneFamilyIdentifier, page, pageSize }, { dataSources }) => {
-                const args = {description, genus, species, strain, identifier, name, geneFamilyIdentifier, page, pageSize};
+            genes: async (_, { description, genus, species, strain, identifier, name, geneFamilyIdentifier, panGeneSetIdentifier, page, pageSize }, { dataSources }) => {
+                const args = {description, genus, species, strain, identifier, name, geneFamilyIdentifier, panGeneSetIdentifier, page, pageSize};
                 return dataSources[sourceName].searchGenes(args)
                 // @ts-ignore: implicit type any error
                     .then(({data: results, metadata: {pageInfo}}) => ({results, pageInfo}));

--- a/src/types/Query.graphql
+++ b/src/types/Query.graphql
@@ -310,7 +310,8 @@ type Query {
   expressionSamples(description: String, page: Int, pageSize: Int): ExpressionSamplesResults
   expressionSources(description: String, page: Int, pageSize: Int): ExpressionSourcesResults
   expressionValues(minValue: Float, geneIdentifier: String, sampleIdentifier: String, page: Int, pageSize: Int): ExpressionValuesResults
-  genes(description: String, genus: String, species: String, strain: String, identifier: String, name: String, geneFamilyIdentifier: String, page: Int, pageSize: Int): GenesResults
+  genes(description: String, genus: String, species: String, strain: String, identifier: String, name: String,
+    geneFamilyIdentifier: String, panGeneSetIdentifier: String, page: Int, pageSize: Int): GenesResults
   geneFamilies(description: String, page: Int, pageSize: Int): GeneFamiliesResults
   geneticMaps(description: String, page: Int, pageSize: Int): GeneticMapsResults
   gwases(description: String, page: Int, pageSize: Int): GwasesResults


### PR DESCRIPTION
Very minor update to main (should  have been in 5.1.0.3-model-updates). Adds `panGeneSetIdentifier` to the filters for searchGenes. Similar to `geneFamilyIdentifier` implementation.