### PR TITLE
Hotfix: Disabled the Intermine version check

### DIFF
--- a/src/data-sources/index.ts
+++ b/src/data-sources/index.ts
@@ -19,7 +19,8 @@ async (intermineURI: string, microservicesURI: string, cache: KeyValueCache):
 Promise<DataSources> => {
   const config = {cache};
   const lisIntermineAPI = new IntermineAPI(intermineURI, config);
-  lisIntermineAPI.verifyIntermineVersion();
+  // TODO: this crashes the server rather than throwing a GraphQL error
+  //lisIntermineAPI.verifyIntermineVersion();
   return {
     lisIntermineAPI,
     lisMicroservicesAPI: new MicroservicesAPI(microservicesURI, config),


### PR DESCRIPTION
This PR disables the Intermine version check. The check was occurring outside of the typical data-source lifecycle so none of the mechanisms provided by Apollo that catch such errors were taking effect. I think the server is still vulnerable to breakage because in certain scenarios Intermine returns an error page instead including an actual error (code) in the response. In other words, this doesn't totally resolve issue #103 but disabling the Intermine version check should make the issue much less prevalent.

Please continue to update issue #103 with <ins>**error messages**</ins> as these errors occur so we can squash them!

I'm not sure how best to test this (maybe @sammyjava can tinker with DNS?). Once merged I'll make a patch release of the server.