### PR TITLE
Renamed interfaces to FooInterface.

### DIFF
--- a/src/data-sources/intermine/api/get-bio-entity.ts
+++ b/src/data-sources/intermine/api/get-bio-entity.ts
@@ -1,0 +1,31 @@
+import {
+  ApiResponse,
+  intermineConstraint,
+  interminePathQuery,
+} from '../intermine.server.js';
+import {
+  GraphQLBioEntity,
+  IntermineBioEntityResponse,
+  intermineBioEntityAttributes,
+  intermineBioEntitySort,
+  response2bioEntities,
+} from '../models/index.js';
+
+
+// get a BioEntity by identifier
+export async function getBioEntity(identifier: string):
+Promise<ApiResponse<GraphQLBioEntity>> {
+    const constraints = [intermineConstraint('BioEntity.primaryIdentifier', '=', identifier)];
+    const query = interminePathQuery(
+        intermineBioEntityAttributes,
+        intermineBioEntitySort,
+        constraints,
+    );
+    return this.pathQuery(query)
+        .then((response: IntermineBioEntityResponse) => response2bioEntities(response))
+        .then((bioentities: Array<GraphQLBioEntity>) => {
+            if (!bioentities.length) return null;
+            return bioentities[0];
+        })
+        .then((bioEntity: GraphQLBioEntity) => ({data: bioEntity}));
+}

--- a/src/data-sources/intermine/api/get-data-sets.ts
+++ b/src/data-sources/intermine/api/get-data-sets.ts
@@ -6,54 +6,26 @@ import {
     response2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
-    GraphQLBioEntity,
+    GraphQLAnnotatable,
     GraphQLDataSet,
-    GraphQLGeneticMap,
-    GraphQLLinkageGroup,
-    GraphQLLocation,
-    GraphQLOntology,
-    GraphQLOntologyAnnotation,
-    GraphQLOntologyTerm,
-    GraphQLPanGeneSet,
-    GraphQLPathway,
-    GraphQLPhylotree,
-    GraphQLSyntenyBlock,
     IntermineDataSetResponse,
     intermineDataSetAttributes,
     intermineDataSetSort,
-    intermineGeneticMapDataSetAttributes,
-    intermineGeneticMapDataSetSort,
-    intermineLinkageGroupDataSetAttributes,
-    intermineLinkageGroupDataSetSort,
-    intermineLocationDataSetAttributes,
-    intermineLocationDataSetSort,
-    intermineOntologyAnnotationDataSetAttributes,
-    intermineOntologyAnnotationDataSetSort,
-    intermineOntologyDataSetAttributes,
-    intermineOntologyDataSetSort,
-    intermineOntologyTermDataSetAttributes,
-    intermineOntologyTermDataSetSort,
-    interminePanGeneSetDataSetAttributes,
-    interminePanGeneSetDataSetSort,
-    interminePathwayDataSetAttributes,
-    interminePathwayDataSetSort,
-    interminePhylotreeDataSetAttributes,
-    interminePhylotreeDataSetSort,
-    intermineSyntenyBlockDataSetAttributes,
-    intermineSyntenyBlockDataSetSort,
     response2dataSets,
 } from '../models/index.js';
 import { PaginationOptions } from './pagination.js';
 
+export type GetDataSetsOptions = {
+    annotatable?: GraphQLAnnotatable;
+} & PaginationOptions;
 
-export async function getDataSetsForBioEntity(
-    bioEntity: GraphQLBioEntity,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
+// get dataSets for types that extend Annotatable using entities reverse reference
+export async function getDataSets(
+    {annotatable, page, pageSize}: GetDataSetsOptions,
 ): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('DataSet.bioEntities.id', '=', bioEntity.id)];
+    const constraints = [
+        intermineConstraint('DataSet.entities.id', '=', annotatable.id)
+    ];
     const query = interminePathQuery(
         intermineDataSetAttributes,
         intermineDataSetSort,
@@ -64,253 +36,6 @@ export async function getDataSetsForBioEntity(
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
     const pageInfoPromise = this.pathQuery(query, {summaryPath: 'DataSet.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
-    // return the expected GraphQL type
-    return Promise.all([dataPromise, pageInfoPromise])
-        .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
-}
-
-
-export async function getDataSetsForGeneticMap(
-    geneticMap: GraphQLGeneticMap,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
-): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('GeneticMap.id', '=', geneticMap.id)];
-    const query = interminePathQuery(
-        intermineGeneticMapDataSetAttributes,
-        intermineGeneticMapDataSetSort,
-        constraints,
-    );
-    // get the data
-    const dataPromise = this.pathQuery(query, {page, pageSize})
-        .then((response: IntermineDataSetResponse) => response2dataSets(response));
-    // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GeneticMap.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
-    // return the expected GraphQL type
-    return Promise.all([dataPromise, pageInfoPromise])
-        .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
-}
-
-
-export async function getDataSetsForLinkageGroup(
-    linkageGroup: GraphQLLinkageGroup,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
-): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('LinkageGroup.id', '=', linkageGroup.id)];
-    const query = interminePathQuery(
-        intermineLinkageGroupDataSetAttributes,
-        intermineLinkageGroupDataSetSort,
-        constraints,
-    );
-    // get the data
-    const dataPromise = this.pathQuery(query, {page, pageSize})
-        .then((response: IntermineDataSetResponse) => response2dataSets(response));
-    // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'LinkageGroup.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
-    // return the expected GraphQL type
-    return Promise.all([dataPromise, pageInfoPromise])
-        .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
-}
-
-
-export async function getDataSetsForLocation(
-    location: GraphQLLocation,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
-): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('Location.id', '=', location.id)];
-    const query = interminePathQuery(
-        intermineLocationDataSetAttributes,
-        intermineLocationDataSetSort,
-        constraints,
-    );
-    // get the data
-    const dataPromise = this.pathQuery(query,  {page, pageSize})
-        .then((response: IntermineDataSetResponse) => response2dataSets(response));
-    // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Location.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
-    // return the expected GraphQL type
-    return Promise.all([dataPromise, pageInfoPromise])
-        .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
-}
-
-
-export async function getDataSetsForOntology(
-    ontology: GraphQLOntology,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
-): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('Ontology.id', '=', ontology.id)];
-    const query = interminePathQuery(
-        intermineOntologyDataSetAttributes,
-        intermineOntologyDataSetSort,
-        constraints,
-    );
-    // get the data
-    const dataPromise = this.pathQuery(query, {page, pageSize})
-        .then((response: IntermineDataSetResponse) => response2dataSets(response));
-    // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Ontology.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
-    // return the expected GraphQL type
-    return Promise.all([dataPromise, pageInfoPromise])
-        .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
-}
-
-
-export async function getDataSetsForOntologyAnnotation(
-    ontologyAnnotation: GraphQLOntologyAnnotation,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
-): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('OntologyAnnotation.id', '=', ontologyAnnotation.id)];
-    const query = interminePathQuery(
-        intermineOntologyAnnotationDataSetAttributes,
-        intermineOntologyAnnotationDataSetSort,
-        constraints,
-    );
-    // get the data
-    const dataPromise = this.pathQuery(query, {page, pageSize})
-        .then((response: IntermineDataSetResponse) => response2dataSets(response));
-    // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'OntologyAnnotation.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
-    // return the expected GraphQL type
-    return Promise.all([dataPromise, pageInfoPromise])
-        .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
-}
-
-
-export async function getDataSetsForOntologyTerm(
-    ontologyTerm: GraphQLOntologyTerm,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
-): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('OntologyTerm.id', '=', ontologyTerm.id)];
-    const query = interminePathQuery(
-        intermineOntologyTermDataSetAttributes,
-        intermineOntologyTermDataSetSort,
-        constraints,
-    );
-    // get the data
-    const dataPromise = this.pathQuery(query, {page, pageSize})
-        .then((response: IntermineDataSetResponse) => response2dataSets(response));
-    // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'OntologyTerm.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
-    // return the expected GraphQL type
-    return Promise.all([dataPromise, pageInfoPromise])
-        .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
-}
-
-export async function getDataSetsForPanGeneSet(
-    panGeneSet: GraphQLPanGeneSet,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
-): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('PanGeneSet.primaryIdentifier', '=', panGeneSet.identifier)];
-    const query = interminePathQuery(
-        interminePanGeneSetDataSetAttributes,
-        interminePanGeneSetDataSetSort,
-        constraints,
-    );
-    // get the data
-    const dataPromise = this.pathQuery(query, {page, pageSize})
-        .then((response: IntermineDataSetResponse) => response2dataSets(response));
-    // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'PanGeneSet.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
-    // return the expected GraphQL type
-    return Promise.all([dataPromise, pageInfoPromise])
-        .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
-}
-
-export async function getDataSetsForPathway(
-    pathway: GraphQLPathway,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
-): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('Pathway.id', '=', pathway.id)];
-    const query = interminePathQuery(
-        interminePathwayDataSetAttributes,
-        interminePathwayDataSetSort,
-        constraints,
-    );
-    // get the data
-    const dataPromise = this.pathQuery(query, {page, pageSize})
-        .then((response: IntermineDataSetResponse) => response2dataSets(response));
-    // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Pathway.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
-    // return the expected GraphQL type
-    return Promise.all([dataPromise, pageInfoPromise])
-        .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
-}
-
-export async function getDataSetsForPhylotree(
-    phylotree: GraphQLPhylotree,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
-): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('Phylotree.id', '=', phylotree.id)];
-    const query = interminePathQuery(
-        interminePhylotreeDataSetAttributes,
-        interminePhylotreeDataSetSort,
-        constraints,
-    );
-    // get the data
-    const dataPromise = this.pathQuery(query, {page, pageSize})
-        .then((response: IntermineDataSetResponse) => response2dataSets(response));
-    // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Phylotree.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
-    // return the expected GraphQL type
-    return Promise.all([dataPromise, pageInfoPromise])
-        .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
-}
-
-
-export async function getDataSetsForSyntenyBlock(
-    syntenyBlock: GraphQLSyntenyBlock,
-    {
-        page,
-        pageSize,
-    }: PaginationOptions,
-): Promise<ApiResponse<GraphQLDataSet>> {
-    const constraints = [intermineConstraint('SyntenyBlock.id', '=', syntenyBlock.id)];
-    const query = interminePathQuery(
-        intermineSyntenyBlockDataSetAttributes,
-        intermineSyntenyBlockDataSetSort,
-        constraints,
-    );
-    // get the data
-    const dataPromise = this.pathQuery(query, {page, pageSize})
-        .then((response: IntermineDataSetResponse) => response2dataSets(response));
-    // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'SyntenyBlock.dataSets.id'})
         .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])

--- a/src/data-sources/intermine/api/get-gene.ts
+++ b/src/data-sources/intermine/api/get-gene.ts
@@ -1,25 +1,47 @@
 import {
-  ApiResponse,
-  intermineConstraint,
-  interminePathQuery,
+    ApiResponse,
+    intermineConstraint,
+    intermineJoin,
+    interminePathQuery,
 } from '../intermine.server.js';
 import {
-  GraphQLGene,
-  IntermineGeneResponse,
-  intermineGeneAttributes,
-  intermineGeneSort,
-  response2genes,
+    GraphQLGene,
+    IntermineGeneResponse,
+    intermineGeneAttributes,
+    intermineGeneSort,
+    response2genes,
 } from '../models/index.js';
 
+// <query name="" model="genomic" view="Gene.primaryIdentifier Gene.supercontig.primaryIdentifier Gene.chromosome.primaryIdentifier Gene.description Gene.name Gene.assemblyVersion Gene.annotationVersion Gene.secondaryIdentifier Gene.organism.taxonId Gene.strain.identifier Gene.length Gene.sequenceOntologyTerm.identifier Gene.chromosomeLocation.start Gene.supercontigLocation.start Gene.sequence.length Gene.ensemblName Gene.upstreamIntergenicRegion.primaryIdentifier Gene.downstreamIntergenicRegion.primaryIdentifier" longDescription="" sortOrder="Gene.primaryIdentifier asc">
+//   <join path="Gene.supercontig" style="OUTER"/>
+//   <join path="Gene.chromosome" style="OUTER"/>
+//   <join path="Gene.chromosomeLocation" style="OUTER"/>
+//   <join path="Gene.supercontigLocation" style="OUTER"/>
+//   <constraint path="Gene.primaryIdentifier" op="=" value="phavu.G19833.gnm1.ann1.Phvul.001G003100"/>
+// </query>
 
-// get a Gene by ID
+// export const intermineJoin =
+//     (path: string, style: 'INNER'|'OUTER'='OUTER'): string => {
+//         return `<join path='${path}' style='${style}'/>`;
+//     };
+
+// get a Gene by primaryIdentifier
 export async function getGene(identifier: string):
 Promise<ApiResponse<GraphQLGene>> {
-    const constraints = [intermineConstraint('Gene.primaryIdentifier', '=', identifier)];
+    const constraints = [
+        intermineConstraint('Gene.primaryIdentifier', '=', identifier)
+    ];
+    const joins = [
+        intermineJoin('Gene.chromosome', 'OUTER'),
+        intermineJoin('Gene.supercontig', 'OUTER'),
+        intermineJoin('Gene.chromosomeLocation', 'OUTER'),
+        intermineJoin('Gene.supercontigLocation', 'OUTER')
+    ];
     const query = interminePathQuery(
         intermineGeneAttributes,
         intermineGeneSort,
         constraints,
+        joins,
     );
     return this.pathQuery(query)
         .then((response: IntermineGeneResponse) => response2genes(response))

--- a/src/data-sources/intermine/api/get-located-features.ts
+++ b/src/data-sources/intermine/api/get-located-features.ts
@@ -21,12 +21,12 @@ export type GetLocationsOptions = {
 } & PaginationOptions;
 
 
-// get locations for any type that extends BioEntity
-export async function getLocations(
+// get locatedFeatures (Locations) for any type that extends BioEntity
+export async function getLocatedFeatures(
     {bioEntity, page, pageSize}: GetLocationsOptions,
 ): Promise<ApiResponse<GraphQLLocation>> {
     const constraints = [
-        intermineConstraint('Location.feature.id', '=', bioEntity.id)
+        intermineConstraint('Location.locatedOn.id', '=', bioEntity.id)
     ];
     const query = interminePathQuery(
         intermineLocationAttributes,

--- a/src/data-sources/intermine/api/index.ts
+++ b/src/data-sources/intermine/api/index.ts
@@ -3,23 +3,13 @@ import { IntermineServer } from '../intermine.server.js';
 // author
 import { getAuthor } from './get-author.js';
 import { getAuthors } from './get-authors.js';
+// bio-entity
+import { getBioEntity } from './get-bio-entity.js';
 // chromosome
 import { getChromosome } from './get-chromosome.js';
 // data set
 import { getDataSet } from './get-data-set.js';
-import {
-    getDataSetsForBioEntity,
-    getDataSetsForGeneticMap,
-    getDataSetsForLinkageGroup,
-    getDataSetsForLocation,
-    getDataSetsForOntologyAnnotation,
-    getDataSetsForOntology,
-    getDataSetsForOntologyTerm,
-    getDataSetsForPanGeneSet,
-    getDataSetsForPathway,
-    getDataSetsForPhylotree,
-    getDataSetsForSyntenyBlock,
-} from './get-data-sets.js';
+import { getDataSets } from './get-data-sets.js';
 // expression sample
 import { getExpressionSample } from './get-expression-sample.js';
 import { getExpressionSamples } from './get-expression-samples.js';
@@ -70,6 +60,8 @@ import { getLinkageGroupPositions } from './get-linkage-group-positions.js';
 // location
 import { getLocation } from './get-location.js';
 import { getLocations } from './get-locations.js';
+// locatedFeatures
+import { getLocatedFeatures } from './get-located-features.js';
 // mRNA
 import { getMRNA } from './get-mrna.js';
 import { getMRNAs } from './get-mrnas.js';
@@ -148,21 +140,13 @@ export declare class ApiMixinInterface {
     // author
     getAuthor: Function;
     getAuthors: Function;
+    // bio-entity
+    getBioEntity: Function;
     // chromosome
     getChromosome: Function;
     // data set
     getDataSet: Function;
-    getDataSetsForBioEntity: Function;
-    getDataSetsForGeneticMap: Function;
-    getDataSetsForLinkageGroup: Function;
-    getDataSetsForLocation: Function;
-    getDataSetsForOntologyAnnotation: Function;
-    getDataSetsForOntology: Function;
-    getDataSetsForOntologyTerm: Function;
-    getDataSetsForPathway: Function;
-    getDataSetsForPanGeneSet: Function;
-    getDataSetsForPhylotree: Function;
-    getDataSetsForSyntenyBlock: Function;
+    getDataSets: Function;
     // expression sample
     getExpressionSample: Function;
     getExpressionSamples: Function;
@@ -213,6 +197,8 @@ export declare class ApiMixinInterface {
     // location
     getLocation: Function;
     getLocations: Function;
+    // locatedFeatures
+    getLocatedFeatures: Function;
     // mRNA
     getMRNA: Function;
     getMRNAs: Function;
@@ -291,31 +277,23 @@ export const ApiMixin = <T extends ApiBaseConstructor<IntermineServer>>(superCla
 
         // Verifies that the version of the IntermineServer is the version the API is expecting
         async verifyIntermineVersion() {
-          const properties = await this.webProperties();
-          const serverVersion = properties['web-properties'].project.releaseVersion;
-          if (serverVersion != ApiMixinClass.intermineVersion) {
-            console.warn(`data-sources: intermine: ${this.baseURL} has version ${serverVersion}; expected ${ApiMixinClass.intermineVersion}`);
-          }
+            const properties = await this.webProperties();
+            const serverVersion = properties['web-properties'].project.releaseVersion;
+            if (serverVersion != ApiMixinClass.intermineVersion) {
+                console.warn(`data-sources: intermine: ${this.baseURL} has version ${serverVersion}; expected ${ApiMixinClass.intermineVersion}`);
+            }
         }
 
         // author
         getAuthor = getAuthor;
         getAuthors = getAuthors;
+        // bio-entity
+        getBioEntity = getBioEntity;
         // chromosome
         getChromosome = getChromosome;
         // data set
         getDataSet = getDataSet;
-        getDataSetsForBioEntity = getDataSetsForBioEntity;
-        getDataSetsForGeneticMap = getDataSetsForGeneticMap;
-        getDataSetsForLinkageGroup = getDataSetsForLinkageGroup;
-        getDataSetsForLocation = getDataSetsForLocation;
-        getDataSetsForOntologyAnnotation = getDataSetsForOntologyAnnotation;
-        getDataSetsForOntology = getDataSetsForOntology;
-        getDataSetsForOntologyTerm = getDataSetsForOntologyTerm;
-        getDataSetsForPathway = getDataSetsForPathway;
-        getDataSetsForPanGeneSet = getDataSetsForPanGeneSet;
-        getDataSetsForPhylotree = getDataSetsForPhylotree;
-        getDataSetsForSyntenyBlock = getDataSetsForSyntenyBlock;
+        getDataSets = getDataSets;
         // expression sample
         getExpressionSample = getExpressionSample;
         getExpressionSamples = getExpressionSamples;
@@ -366,6 +344,8 @@ export const ApiMixin = <T extends ApiBaseConstructor<IntermineServer>>(superCla
         // location
         getLocation = getLocation;
         getLocations = getLocations;
+        // locatedFeatures
+        getLocatedFeatures = getLocatedFeatures;
         // mRNA
         getMRNA = getMRNA;
         getMRNAs = getMRNAs;

--- a/src/data-sources/intermine/models/bio-entity.ts
+++ b/src/data-sources/intermine/models/bio-entity.ts
@@ -1,5 +1,65 @@
-import { GraphQLSequenceFeature } from './sequence-feature.js';
+import { IntermineDataResponse, response2graphqlObjects } from '../intermine.server.js';
+
+// <class name="BioEntity" extends="Annotatable" is-interface="true" term="">
+// 	<attribute name="description" type="java.lang.String"/>
+// 	<attribute name="symbol" type="java.lang.String" term="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+// 	<attribute name="name" type="java.lang.String" term="http://www.w3.org/2000/01/rdf-schema#label"/>
+// 	<attribute name="assemblyVersion" type="java.lang.String"/>
+// 	<attribute name="annotationVersion" type="java.lang.String"/>
+// 	<attribute name="secondaryIdentifier" type="java.lang.String" term="http://semanticscience.org/resource/SIO_000673"/>
+// 	<reference name="organism" referenced-type="Organism" term="http://purl.org/net/orth#organism"/>
+// 	<reference name="strain" referenced-type="Strain" term="http://semanticscience.org/resource/SIO_010055"/>
+// 	<collection name="locations" referenced-type="Location" reverse-reference="feature"/>
+// 	<collection name="synonyms" referenced-type="Synonym" reverse-reference="subject" term="http://purl.obolibrary.org/obo/synonym"/>
+// 	<collection name="crossReferences" referenced-type="CrossReference" reverse-reference="subject" term="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+// 	<collection name="dataSets" referenced-type="DataSet" reverse-reference="bioEntities" term="http://semanticscience.org/resource/SIO_001278"/>
+// 	<collection name="locatedFeatures" referenced-type="Location" reverse-reference="locatedOn"/>
+// </class>
+export const intermineBioEntityAttributes = [
+    'BioEntity.id',
+    'BioEntity.primaryIdentifier',
+    'BioEntity.description',
+    'BioEntity.symbol',
+    'BioEntity.name',
+    'BioEntity.assemblyVersion',
+    'BioEntity.annotationVersion',
+    'BioEntity.secondaryIdentifier',
+    'BioEntity.organism.taxonId',  // resolve reference
+    'BioEntity.strain.identifier', // resolve reference
+];
+export const intermineBioEntitySort = 'BioEntity.primaryIdentifier';
+export type IntermineBioEntity = [
+    number,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    number,
+    string,
+];
+
+export const graphqlBioEntityAttributes = [
+    'id',
+    'identifier',
+    'description',
+    'symbol',
+    'name',
+    'assemblyVersion',
+    'annotationVersion',
+    'secondaryIdentifier',
+    'organismTaxonId',
+    'strainIdentifier',
+];
+export type GraphQLBioEntity = {
+    [prop in typeof graphqlBioEntityAttributes[number]]: string;
+}
 
 
-export type GraphQLBioEntity =
-  GraphQLSequenceFeature;  // all SequenceFeatures are BioEntities
+export type IntermineBioEntityResponse = IntermineDataResponse<IntermineBioEntity>;
+// converts an Intermine response into an array of GraphQL BioEntity objects
+export function response2bioEntities(response: IntermineBioEntityResponse): Array<GraphQLBioEntity> {
+    return response2graphqlObjects(response, graphqlBioEntityAttributes);
+}

--- a/src/data-sources/intermine/models/gene.ts
+++ b/src/data-sources/intermine/models/gene.ts
@@ -28,9 +28,9 @@ import { IntermineDataResponse, response2graphqlObjects } from '../intermine.ser
 // 	<reference name="downstreamIntergenicRegion" referenced-type="IntergenicRegion" term="http://purl.obolibrary.org/obo/SO_0000605"/>
 export const intermineGeneAttributes = [
     'Gene.id',
-    // Annotatable
+    //// Annotatable
     'Gene.primaryIdentifier',
-    // BioEntity
+    //// BioEntity
     'Gene.description',
     'Gene.symbol',
     'Gene.name',
@@ -39,7 +39,7 @@ export const intermineGeneAttributes = [
     'Gene.secondaryIdentifier',
     'Gene.organism.taxonId',   // reference resolution
     'Gene.strain.identifier',  // reference resolution
-    // SequenceFeature
+    //// SequenceFeature
     'Gene.score',
     'Gene.scoreType',
     'Gene.length',
@@ -49,7 +49,7 @@ export const intermineGeneAttributes = [
     'Gene.sequence.id', // reference resolution
     'Gene.chromosome.primaryIdentifier', // reference resolution
     'Gene.supercontig.primaryIdentifier', // reference resolution
-    // Gene
+    //// Gene
     'Gene.briefDescription',
     'Gene.ensemblName',
     'Gene.upstreamIntergenicRegion.primaryIdentifier', // reference resolution
@@ -58,18 +58,18 @@ export const intermineGeneAttributes = [
 export const intermineGeneSort = 'Gene.primaryIdentifier'; // guaranteed not null
 export type IntermineGene = [
     number,
-    // Annotatable
+    //// Annotatable
     string,
-    // BioEntity
-    string,
-    string,
+    //// BioEntity
     string,
     string,
     string,
     string,
     string,
     string,
-    // SequenceFeature
+    string,
+    string,
+    //// SequenceFeature
     number,
     string,
     number,
@@ -79,40 +79,13 @@ export type IntermineGene = [
     number,
     string,
     string,
-    // Gene
+    //// Gene
     string,
     string,
     string,
     string
 ];
 
-// 'Gene.id',
-// // Annotatable
-// 'Gene.primaryIdentifier',
-// // BioEntity
-// 'Gene.description',
-// 'Gene.symbol',
-// 'Gene.name',
-// 'Gene.assemblyVersion',
-// 'Gene.annotationVersion',
-// 'Gene.secondaryIdentifier',
-// 'Gene.organism.taxonId',   // reference resolution
-// 'Gene.strain.identifier',  // reference resolution
-// // SequenceFeature
-// 'Gene.score',
-// 'Gene.scoreType',
-// 'Gene.length',
-// 'Gene.sequenceOntologyTerm.identifier', // reference resolution
-// 'Gene.chromosomeLocation.id',   // reference resolution
-// 'Gene.supercontigLocation.id',  // reference resolution
-// 'Gene.sequence.id', // reference resolution
-// 'Gene.chromosome.primaryIdentifier', // reference resolution
-// 'Gene.supercontig.primaryIdentifier', // reference resolution
-// // Gene
-// 'Gene.briefDescription',
-// 'Gene.ensemblName',
-// 'Gene.upstreamIntergenicRegion.primaryIdentifier', // reference resolution
-// 'Gene.downstreamIntergenicRegion.primaryIdentifier', // reference resolution
 export const graphqlGeneAttributes = [
     'id',
     'identifier',

--- a/src/data-sources/intermine/models/index.ts
+++ b/src/data-sources/intermine/models/index.ts
@@ -1,5 +1,6 @@
 
 import { GraphQLAuthor, IntermineAuthor } from './author.js';
+import { GraphQLBioEntity, IntermineBioEntity } from './bio-entity.js';
 import { GraphQLChromosome, IntermineChromosome } from './chromosome.js';
 import { GraphQLDataSet, IntermineDataSet } from './data-set.js';
 import { GraphQLExpressionSample, IntermineExpressionSample } from './expression-sample.js';
@@ -41,6 +42,7 @@ import { GraphQLTrait, IntermineTrait } from './trait.js';
 
 export type GraphQLModel =
     GraphQLAuthor |
+    GraphQLBioEntity |
     GraphQLChromosome |
     GraphQLDataSet |
     GraphQLExpressionSample |
@@ -82,6 +84,7 @@ export type GraphQLModel =
 
 export type IntermineModel =
     IntermineAuthor |
+    IntermineBioEntity |
     IntermineChromosome |
     IntermineDataSet |
     IntermineExpressionSample |

--- a/src/data-sources/intermine/models/location.ts
+++ b/src/data-sources/intermine/models/location.ts
@@ -15,14 +15,16 @@ export const intermineLocationAttributes = [
     'Location.start',
     'Location.end',
     'Location.locatedOn.primaryIdentifier',
+    'Location.feature.primaryIdentifier'
 ];
 export const intermineLocationSort = 'Location.start'; // guaranteed not null
 export type IntermineLocation = [
-  number,
-  string,
-  number,
-  number,
-  string,
+    number,
+    string,
+    number,
+    number,
+    string,
+    string,
 ];
 
 
@@ -31,8 +33,8 @@ export type IntermineLocation = [
 //   strand: String
 //   start: Int
 //   end: Int
-//   # locatedOn
-//   # feature
+//   locatedOn
+//   feature
 //   # dataSets
 // }
 export const graphqlLocationAttributes = [
@@ -40,10 +42,11 @@ export const graphqlLocationAttributes = [
     'strand',
     'start',
     'end',
-    'locatedOnIdentifier',
+    'locatedOnIdentifier', // reference resolution
+    'featureIdentifier',   // reference resolution
 ];
 export type GraphQLLocation = {
-  [prop in typeof graphqlLocationAttributes[number]]: string;
+    [prop in typeof graphqlLocationAttributes[number]]: string;
 }
 
 
@@ -67,12 +70,12 @@ export const intermineLocationDataSetAttributes = [
 ];
 export const intermineLocationDataSetSort = 'Location.dataSets.name'; // guaranteed not null
 export type IntermineLocationDataSet = [
-  number,
-  string,
-  string,
-  string,
-  string,
-  string,
-  string,
-  string,
+    number,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
 ];

--- a/src/resolvers/intermine/bio-entity.ts
+++ b/src/resolvers/intermine/bio-entity.ts
@@ -8,24 +8,30 @@ export const bioEntityFactory =
 (sourceName: KeyOfType<DataSources, IntermineAPI>): SubfieldResolverMap => ({
     ...annotatableFactory(sourceName),
     organism: async (bioEntity, _, { dataSources }) => {
-        return dataSources[sourceName].getOrganism(bioEntity.organismTaxonId)
+        return dataSources[sourceName].getOrganism(bioEntity)
             // @ts-ignore: implicit type any error
             .then(({data: results}) => results);
     },
     strain: async (bioEntity, _, { dataSources }) => {
-        return dataSources[sourceName].getStrain(bioEntity.strainIdentifier)
+        return dataSources[sourceName].getStrain(bioEntity)
             // @ts-ignore: implicit type any error
             .then(({data: results}) => results);
     },
     locations: async (bioEntity, { page, pageSize }, { dataSources }) => {
-        const args = {sequenceFeature: bioEntity, page, pageSize};
+        const args = {bioEntity: bioEntity, page, pageSize};
         return dataSources[sourceName].getLocations(args)
             // @ts-ignore: implicit type any error
             .then(({data: results}) => results);
     },
     dataSets: async (bioEntity, { page, pageSize }, { dataSources }) => {
-        const args = {page, pageSize};
-        return dataSources[sourceName].getDataSetsForBioEntity(bioEntity, args)
+        const args = {bioEntity: bioEntity, page, pageSize};
+        return dataSources[sourceName].getDataSets(args)
+            // @ts-ignore: implicit type any error
+            .then(({data: results}) => results);
+    },
+    locatedFeatures: async (bioEntity, { page, pageSize }, { dataSources }) => {
+        const args = {bioEntity: bioEntity, page, pageSize};
+        return dataSources[sourceName].getLocatedFeatures(args)
             // @ts-ignore: implicit type any error
             .then(({data: results}) => results);
     },

--- a/src/resolvers/intermine/genetic-map.ts
+++ b/src/resolvers/intermine/genetic-map.ts
@@ -35,8 +35,8 @@ ResolverMap => ({
                 .then(({data: results}) => results);
         },
         dataSets: async (geneticMap, { page, pageSize }, { dataSources }) => {
-            const args = {page, pageSize};
-            return dataSources[sourceName].getDataSetsForGeneticMap(geneticMap, args)
+            const args = {bioEntity: geneticMap, page, pageSize};
+            return dataSources[sourceName].getDataSets(args)
                 // @ts-ignore: implicit type any error
                 .then(({data: results}) => results);
         },

--- a/src/resolvers/intermine/genotyping-platform.ts
+++ b/src/resolvers/intermine/genotyping-platform.ts
@@ -18,13 +18,12 @@ ResolverMap => ({
     },
     GenotypingPlatform: {
         ...annotatableFactory(sourceName),
-        //     Doesn't have dataSets, maybe add in future mine model.
-        //     dataSets: async (genotypingPlatform, { page, pageSize }, { dataSources }) => {
-        //         const args = {page, pageSize};
-        //         return dataSources[sourceName].getDataSetsForGenotypingPlatform(genotypingPlatform, args)
-        //         // @ts-ignore: implicit type any error
-        //             .then(({data: results}) => results);
-        //     },
+        dataSets: async (genotypingPlatform, { page, pageSize }, { dataSources }) => {
+            const args = {annotatable: genotypingPlatform, page, pageSize};
+            return dataSources[sourceName].getDataSets(args)
+            // @ts-ignore: implicit type any error
+                .then(({data: results}) => results);
+        },
         markers: async (genotypingPlatform, { page, pageSize }, { dataSources }) => {
             const args = {genotypingPlatform, page, pageSize};
             return dataSources[sourceName].getGeneticMarkers(args)

--- a/src/resolvers/intermine/linkage-group.ts
+++ b/src/resolvers/intermine/linkage-group.ts
@@ -24,8 +24,8 @@ ResolverMap => ({
                 .then(({data: results}) => results);
         },
         dataSets: async (linkageGroup, { page, pageSize }, { dataSources }) => {
-            const args = {page, pageSize};
-            return dataSources[sourceName].getDataSetsForLinkageGroup(linkageGroup, args)
+            const args = {bioEntity: linkageGroup, page, pageSize};
+            return dataSources[sourceName].getDataSets(args)
                 // @ts-ignore: implicit type any error
                 .then(({data: results}) => results);
         },

--- a/src/resolvers/intermine/location.ts
+++ b/src/resolvers/intermine/location.ts
@@ -4,40 +4,52 @@ import { ResolverMap } from '../resolver.js';
 
 
 export const locationFactory =
-(
-    sourceName: KeyOfType<DataSources, IntermineAPI>,
-    microservicesSource: KeyOfType<DataSources, MicroservicesAPI>,
-): ResolverMap => ({
-    Query: {
-        location: async (_, { id }, { dataSources }) => {
-            const {data: location} = await dataSources[sourceName].getLocation(id);
-            if (location == null) {
-                const msg = `Location with ID '${id}' not found`;
-                inputError(msg);
-            }
-            return {results: location};
+    (
+        sourceName: KeyOfType<DataSources, IntermineAPI>,
+        microservicesSource: KeyOfType<DataSources, MicroservicesAPI>,
+    ): ResolverMap => ({
+        Query: {
+            location: async (_, { id }, { dataSources }) => {
+                const {data: location} = await dataSources[sourceName].getLocation(id);
+                if (location == null) {
+                    const msg = `Location with ID '${id}' not found`;
+                    inputError(msg);
+                }
+                return {results: location};
+            },
         },
-    },
-    Location: {
-        chromosome: async (location, _, { dataSources }) => {
-            return dataSources[sourceName].getChromosome(location.locatedOnIdentifier)
+        Location: {
+            feature: async (location, _, { dataSources }) => {
+                return dataSources[sourceName].getBioEntity(location.featureIdentifier)
                 // @ts-ignore: implicit type any error
-                .then(({data: results}) => results);
-        },
-        supercontig: async (location, _, { dataSources }) => {
-            return dataSources[sourceName].getSupercontig(location.locatedOnIdentifier)
+                    .then(({data: results}) => results);
+            },
+            dataSets: async (location, { page, pageSize }, { dataSources }) => {
+                const args = {bioEntity: location, page, pageSize};
+                return dataSources[sourceName].getDataSets(args)
                 // @ts-ignore: implicit type any error
-                .then(({data: results}) => results);
-        },
-        dataSets: async (location, { page, pageSize }, { dataSources }) => {
-            const args = {page, pageSize};
-            return dataSources[sourceName].getDataSetsForLocation(location, args)
+                    .then(({data: results}) => results);
+            },
+            // locatedOn breakout:
+            chromosome: async (location, _, { dataSources }) => {
+                return dataSources[sourceName].getChromosome(location.locatedOnIdentifier)
                 // @ts-ignore: implicit type any error
-                .then(({data: results}) => results);
+                    .then(({data: results}) => results);
+            },
+            supercontig: async (location, _, { dataSources }) => {
+                return dataSources[sourceName].getSupercontig(location.locatedOnIdentifier)
+                // @ts-ignore: implicit type any error
+                    .then(({data: results}) => results);
+            },
+            protein: async (location, _, { dataSources }) => {
+                return dataSources[sourceName].getProtein(location.locatedOnIdentifier)
+                // @ts-ignore: implicit type any error
+                    .then(({data: results}) => results);
+            },
+            // microservices
+            linkouts: async (location, _, { dataSources }) => {
+                const {locatedOnIdentifier, start, end} = location;
+                return dataSources[microservicesSource].getLinkoutsForLocation(locatedOnIdentifier, start, end);
+            },
         },
-        linkouts: async (location, _, { dataSources }) => {
-          const {locatedOnIdentifier, start, end} = location;
-          return dataSources[microservicesSource].getLinkoutsForLocation(locatedOnIdentifier, start, end);
-        },
-    },
-});
+    });

--- a/src/resolvers/intermine/ontology-annotation.ts
+++ b/src/resolvers/intermine/ontology-annotation.ts
@@ -22,8 +22,8 @@ ResolverMap => ({
                 .then(({data: results}) => results);
         },
         dataSets: async (ontologyAnnotation, { page, pageSize }, { dataSources }) => {
-            const args = {page, pageSize};
-            return dataSources[sourceName].getDataSetsForOntologyAnnotation(ontologyAnnotation, args)
+            const args = {bioEntity: ontologyAnnotation, page, pageSize};
+            return dataSources[sourceName].getDataSets(args)
                 // @ts-ignore: implicit type any error
                 .then(({data: results}) => results);
         },

--- a/src/resolvers/intermine/ontology-term.ts
+++ b/src/resolvers/intermine/ontology-term.ts
@@ -29,8 +29,8 @@ ResolverMap => ({
                 .then(({data: results}) => results);
         },
         dataSets: async (ontologyTerm, { page, pageSize }, { dataSources }) => {
-            const args = {page, pageSize};
-            return dataSources[sourceName].getDataSetsForOntologyTerm(ontologyTerm, args)
+            const args = {bioEntity: ontologyTerm, page, pageSize};
+            return dataSources[sourceName].getDataSets(args)
                 // @ts-ignore: implicit type any error
                 .then(({data: results}) => results);
         },

--- a/src/resolvers/intermine/ontology.ts
+++ b/src/resolvers/intermine/ontology.ts
@@ -17,8 +17,8 @@ ResolverMap => ({
     },
     Ontology: {
         dataSets: async (ontology, { page, pageSize }, { dataSources }) => {
-            const args = {page, pageSize};
-            return dataSources[sourceName].getDataSetsForOntology(ontology, args)
+            const args = {bioEntity: ontology, page, pageSize};
+            return dataSources[sourceName].getDataSets(args)
                 // @ts-ignore: implicit type any error
                 .then(({data: results}) => results);
         },

--- a/src/resolvers/intermine/pan-gene-set.ts
+++ b/src/resolvers/intermine/pan-gene-set.ts
@@ -19,8 +19,8 @@ ResolverMap => ({
     PanGeneSet: {
         ...annotatableFactory(sourceName),
         dataSets: async (panGeneSet, { page, pageSize }, { dataSources }) => {
-            const args = {page, pageSize};
-            return dataSources[sourceName].getDataSetsForPanGeneSet(panGeneSet, args)
+            const args = {bioEntity: panGeneSet, page, pageSize};
+            return dataSources[sourceName].getDataSets(args)
                 // @ts-ignore: implicit type any error
                 .then(({data: results}) => results);
         },

--- a/src/resolvers/intermine/pathway.ts
+++ b/src/resolvers/intermine/pathway.ts
@@ -19,8 +19,8 @@ ResolverMap => ({
     Pathway: {
         ...annotatableFactory(sourceName),
         dataSets: async (pathway, { page, pageSize }, { dataSources }) => {
-            const args = {page, pageSize};
-            return dataSources[sourceName].getDataSetsForPathway(pathway, args)
+            const args = {bioEntity: pathway, page, pageSize};
+            return dataSources[sourceName].getDataSets(args)
                 // @ts-ignore: implicit type any error
                 .then(({data: results}) => results);
         },

--- a/src/resolvers/intermine/phylotree.ts
+++ b/src/resolvers/intermine/phylotree.ts
@@ -32,8 +32,8 @@ ResolverMap => ({
                 });
         },
         dataSets: async (phylotree, { page, pageSize }, { dataSources }) => {
-            const args = {page, pageSize};
-            return dataSources[sourceName].getDataSetsForPhylotree(phylotree, args)
+            const args = {bioEntity: phylotree, page, pageSize};
+            return dataSources[sourceName].getDataSets(args)
                 // @ts-ignore: implicit type any error
                 .then(({data: results}) => results);
         },

--- a/src/resolvers/intermine/sequence-feature.ts
+++ b/src/resolvers/intermine/sequence-feature.ts
@@ -5,6 +5,39 @@ import { bioEntityFactory } from './bio-entity.js';
 
 
 export const sequenceFeatureFactory =
-(sourceName: KeyOfType<DataSources, IntermineAPI>): SubfieldResolverMap => ({
-    ...bioEntityFactory(sourceName),
-});
+    (sourceName: KeyOfType<DataSources, IntermineAPI>): SubfieldResolverMap => ({
+        ...bioEntityFactory(sourceName),
+        sequenceOntologyTerm: async (sequenceFeature, _, { dataSources }) => {
+            return dataSources[sourceName].getSequenceOntologyTerm(sequenceFeature)
+            // @ts-ignore: implicit type any error
+                .then(({data: results}) => results);
+        },
+        chromosomeLocation: async (sequenceFeature, _, { dataSources }) => {
+            return dataSources[sourceName].getChromosomeLocation(sequenceFeature)
+            // @ts-ignore: implicit type any error
+                .then(({data: results}) => results);
+        },
+        supercontigLocation: async (sequenceFeature, _, { dataSources }) => {
+            return dataSources[sourceName].getSupercontigLocation(sequenceFeature)
+            // @ts-ignore: implicit type any error
+                .then(({data: results}) => results);
+        },
+        chromosome: async (sequenceFeature, _, { dataSources }) => {
+            const args = {page, pageSize};
+            return dataSources[sourceName].getChromosome(sequenceFeature)
+            // @ts-ignore: implicit type any error
+                .then(({data: results}) => results);
+        },
+        overlappingFeatures: async (sequenceFeature, { page, pageSize }, { dataSources }) => {
+            const args = {sequenceFeature: sequenceFeature, page, pageSize};
+            return dataSources[sourceName].getOverlappingFeatures(args)
+            // @ts-ignore: implicit type any error
+                .then(({data: results}) => results);
+        },
+        childFeatures: async (sequenceFeature, { page, pageSize }, { dataSources }) => {
+            const args = {sequenceFeature: sequenceFeature, page, pageSize};
+            return dataSources[sourceName].getChildFeatures(args)
+            // @ts-ignore: implicit type any error
+                .then(({data: results}) => results);
+        },
+    });

--- a/src/resolvers/intermine/synteny-block.ts
+++ b/src/resolvers/intermine/synteny-block.ts
@@ -23,8 +23,8 @@ ResolverMap => ({
                 .then(({data: results}) => results);
         },
         dataSets: async (syntenyBlock, { page, pageSize }, { dataSources }) => {
-            const args = {page, pageSize};
-            return dataSources[sourceName].getDataSetsForSyntenyBlock(syntenyBlock, args)
+            const args = {bioEntity: syntenyBlock, page, pageSize};
+            return dataSources[sourceName].getDataSets(args)
                 // @ts-ignore: implicit type any error
                 .then(({data: results}) => results);
         },

--- a/src/types/AnnotatableInterface.graphql
+++ b/src/types/AnnotatableInterface.graphql
@@ -6,8 +6,7 @@
 # 	<collection name="ontologyAnnotations" referenced-type="OntologyAnnotation" reverse-reference="subject" term="http://semanticscience.org/resource/SIO_000255"/>
 # 	<collection name="publications" referenced-type="Publication" reverse-reference="entities" term="http://purl.org/dc/terms/bibliographicCitation"/>
 # </class>
-## core type
-type Annotatable implements AnnotatableInterface {
+interface AnnotatableInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/BioEntityInterface.graphql
+++ b/src/types/BioEntityInterface.graphql
@@ -16,7 +16,7 @@
 # 	<collection name="dataSets" referenced-type="DataSet" reverse-reference="bioEntities" term="http://semanticscience.org/resource/SIO_001278"/>
 # 	<collection name="locatedFeatures" referenced-type="Location" reverse-reference="locatedOn"/>
 # </class>
-type BioEntity implements BioEntityInterface {
+interface BioEntityInterface implements AnnotatableInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/CDS.graphql
+++ b/src/types/CDS.graphql
@@ -2,7 +2,7 @@
 # 	<attribute name="isPrimary" type="java.lang.Boolean"/>
 # 	<reference name="transcript" referenced-type="Transcript" reverse-reference="CDSs"/>
 # </class>
-type CDS implements SequenceFeature & BioEntity & Annotatable {
+type CDS implements SequenceFeatureInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/Chromosome.graphql
+++ b/src/types/Chromosome.graphql
@@ -1,5 +1,5 @@
 # <class name="Chromosome" extends="SequenceFeature" is-interface="true" term="http://purl.obolibrary.org/obo/SO:0000340,http://purl.obolibrary.org/obo/SO_0000340"></class>
-type Chromosome implements SequenceFeature & BioEntity & Annotatable {
+type Chromosome implements SequenceFeatureInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/Exon.graphql
+++ b/src/types/Exon.graphql
@@ -1,7 +1,7 @@
 # <class name="Exon" extends="SequenceFeature" is-interface="true" term="http://purl.obolibrary.org/obo/SO:0000147,http://purl.obolibrary.org/obo/SO_0000147">
 # 	<collection name="transcripts" referenced-type="Transcript" reverse-reference="exons"/>
 # </class>
-type Exon implements SequenceFeature & BioEntity & Annotatable {
+type Exon implements SequenceFeatureInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/ExpressionSample.graphql
+++ b/src/types/ExpressionSample.graphql
@@ -12,7 +12,7 @@
 # 	<attribute name="developmentStage" type="java.lang.String"/>
 # 	<reference name="source" referenced-type="ExpressionSource" reverse-reference="samples"/>
 # </class>
-type ExpressionSample implements Annotatable {
+type ExpressionSample implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/ExpressionSource.graphql
+++ b/src/types/ExpressionSource.graphql
@@ -10,7 +10,7 @@
 # 	<reference name="dataSet" referenced-type="DataSet"/>
 # 	<collection name="samples" referenced-type="ExpressionSample" reverse-reference="source"/>
 # </class>
-type ExpressionSource implements Annotatable {
+type ExpressionSource implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/GWAS.graphql
+++ b/src/types/GWAS.graphql
@@ -8,7 +8,7 @@
 # 	<reference name="dataSet" referenced-type="DataSet"/>
 # 	<collection name="results" referenced-type="GWASResult" reverse-reference="gwas"/>
 # </class>
-type GWAS implements Annotatable {
+type GWAS implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/Gene.graphql
+++ b/src/types/Gene.graphql
@@ -14,9 +14,9 @@
 # 	<collection name="regulatoryRegions" referenced-type="RegulatoryRegion" reverse-reference="gene"/>
 # 	<collection name="pathways" referenced-type="Pathway" reverse-reference="genes"/>
 # </class>
-type Gene implements SequenceFeature & BioEntity & Annotatable {
+type Gene implements SequenceFeatureInterface {
   id: ID!
-  # Annotatable
+  ## Annotatable
   identifier: ID!
   ontologyAnnotations: [OntologyAnnotation!]!
   publications: [Publication!]!
@@ -32,7 +32,7 @@ type Gene implements SequenceFeature & BioEntity & Annotatable {
   locations: [Location!]!
   dataSets: [DataSet!]!
   locatedFeatures: [Location!]!
-  # SequenceFeature
+  ## SequenceFeature
   score: Float
   scoreType: String
   length: Int

--- a/src/types/GeneFamily.graphql
+++ b/src/types/GeneFamily.graphql
@@ -9,7 +9,7 @@
 # 	<collection name="dataSets" referenced-type="DataSet"/>
 # 	<collection name="tallies" referenced-type="GeneFamilyTally" reverse-reference="geneFamily"/>
 # </class>
-type GeneFamily implements Annotatable {
+type GeneFamily implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/GeneFlankingRegion.graphql
+++ b/src/types/GeneFlankingRegion.graphql
@@ -4,7 +4,7 @@
 # 	<attribute name="includeGene" type="java.lang.Boolean"/>
 # 	<reference name="gene" referenced-type="Gene" reverse-reference="flankingRegions" term="http://purl.obolibrary.org/obo/SO:0000704"/>
 # </class>
-type GeneFlankingRegion implements SequenceFeature & BioEntity & Annotatable {
+type GeneFlankingRegion implements SequenceFeatureInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/GeneticMap.graphql
+++ b/src/types/GeneticMap.graphql
@@ -8,7 +8,7 @@
 # 	<collection name="linkageGroups" referenced-type="LinkageGroup" reverse-reference="geneticMap"/>
 # 	<collection name="dataSets" referenced-type="DataSet"/>
 # </class>
-type GeneticMap implements Annotatable {
+type GeneticMap implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/GeneticMarker.graphql
+++ b/src/types/GeneticMarker.graphql
@@ -8,7 +8,7 @@
 # 	<collection name="gwasResults" referenced-type="GWASResult" reverse-reference="markers"/>
 # 	<collection name="linkageGroupPositions" referenced-type="LinkageGroupPosition"/>
 # </class>
-type GeneticMarker implements SequenceFeature & BioEntity & Annotatable {
+type GeneticMarker implements SequenceFeatureInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/GenotypingPlatform.graphql
+++ b/src/types/GenotypingPlatform.graphql
@@ -4,7 +4,7 @@
 # 	<collection name="publications" referenced-type="Publication" reverse-reference="entities" term="http://purl.org/dc/terms/bibliographicCitation"/>
 #       <collection name="markers" referenced-type="GeneticMarker" reverse-reference="genotypingPlatforms"/>
 # </class>
-type GenotypingPlatform implements Annotatable {
+type GenotypingPlatform implements AnnotatableInterface {
   ## Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/IntergenicRegion.graphql
+++ b/src/types/IntergenicRegion.graphql
@@ -1,7 +1,7 @@
 # <class name="IntergenicRegion" extends="SequenceFeature" is-interface="true" term="http://purl.obolibrary.org/obo/SO_0000605,http://purl.obolibrary.org/obo/SO:0000605">
 # 	<collection name="adjacentGenes" referenced-type="Gene"/>
 # </class>
-type IntergenicRegion implements SequenceFeature & BioEntity & Annotatable {
+type IntergenicRegion implements SequenceFeatureInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/Intron.graphql
+++ b/src/types/Intron.graphql
@@ -2,7 +2,7 @@
 # 	<collection name="transcripts" referenced-type="Transcript" reverse-reference="introns" term="http://purl.obolibrary.org/obo/SO_0000673"/>
 # 	<collection name="genes" referenced-type="Gene" reverse-reference="introns" term="http://purl.obolibrary.org/obo/SO:0000704"/>
 # </class>
-type Intron implements SequenceFeature & BioEntity & Annotatable {
+type Intron implements SequenceFeatureInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/LinkageGroup.graphql
+++ b/src/types/LinkageGroup.graphql
@@ -6,7 +6,7 @@
 # 	<collection name="qtls" referenced-type="QTL" reverse-reference="linkageGroup"/>
 # 	<collection name="dataSets" referenced-type="DataSet"/>
 # </class>
-type LinkageGroup implements Annotatable {
+type LinkageGroup implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/Location.graphql
+++ b/src/types/Location.graphql
@@ -6,15 +6,19 @@
 # 	<reference name="feature" referenced-type="BioEntity" reverse-reference="locations"/>
 # 	<collection name="dataSets" referenced-type="DataSet"/>
 # </class>
-## NOTE: Restrict locatedOn to be a chromosome or supercontig.
+## NOTE: right now, locatedOn can be a Chromosome, Supercontig, or Protein.
+## We break them out into separate subtypes here.
 type Location {
   id: ID!
   strand: String
   start: Int
   end: Int
+  feature: BioEntity
+  dataSets: [DataSet!]!
+  ## locatedOn breakout:
   chromosome: Chromosome
   supercontig: Supercontig
-  # feature
-  dataSets: [DataSet!]!
+  protein: Protein
+  ## microservices
   linkouts: [Linkout!]!
 }

--- a/src/types/MRNA.graphql
+++ b/src/types/MRNA.graphql
@@ -1,7 +1,7 @@
 # <class name="MRNA" extends="Transcript" is-interface="true" term="http://purl.obolibrary.org/obo/SO:0000234">
 # 	<attribute name="isPrimary" type="java.lang.Boolean"/>
 # </class>
-type MRNA implements Transcript & SequenceFeature & BioEntity & Annotatable {
+type MRNA implements TranscriptInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/PanGeneSet.graphql
+++ b/src/types/PanGeneSet.graphql
@@ -4,7 +4,7 @@
 # 	<collection name="proteins" referenced-type="Protein" reverse-reference="panGeneSets"/>
 # 	<collection name="dataSets" referenced-type="DataSet"/>
 # </class>
-type PanGeneSet implements Annotatable {
+type PanGeneSet implements AnnotatableInterface {
   ## Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/Pathway.graphql
+++ b/src/types/Pathway.graphql
@@ -4,7 +4,7 @@
 # 	<collection name="genes" referenced-type="Gene" reverse-reference="pathways"/>
 # 	<collection name="dataSets" referenced-type="DataSet"/>
 # </class>
-type Pathway implements Annotatable {
+type Pathway implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/Phylotree.graphql
+++ b/src/types/Phylotree.graphql
@@ -10,7 +10,7 @@
 #         <reference name="phylotree" referenced-type="Phylotree"/>
 #         <reference name="geneFamily" referenced-type="GeneFamily"/>
 # </class> 
-type Phylotree implements Annotatable {
+type Phylotree implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/Protein.graphql
+++ b/src/types/Protein.graphql
@@ -12,7 +12,7 @@
 # 	<collection name="panGeneSets" referenced-type="PanGeneSet" reverse-reference="proteins"/>
 # 	<collection name="geneFamilyAssignments" referenced-type="GeneFamilyAssignment"/>
 # </class>
-type Protein implements BioEntity & Annotatable {
+type Protein implements BioEntityInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/ProteinDomain.graphql
+++ b/src/types/ProteinDomain.graphql
@@ -10,7 +10,7 @@
 # 	<collection name="parentFeatures" referenced-type="ProteinDomain"/>
 # 	<collection name="contains" referenced-type="ProteinDomain"/>
 # </class>
-type ProteinDomain implements Annotatable {
+type ProteinDomain implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/ProteinMatch.graphql
+++ b/src/types/ProteinMatch.graphql
@@ -8,7 +8,7 @@
 # 	<attribute name="accession" type="java.lang.String"/>
 # 	<reference name="protein" referenced-type="Protein" reverse-reference="proteinMatches"/>
 # </class>
-type ProteinMatch implements BioEntity & Annotatable {
+type ProteinMatch implements BioEntityInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/QTL.graphql
+++ b/src/types/QTL.graphql
@@ -14,7 +14,7 @@
 # 	<collection name="genes" referenced-type="Gene"/>
 # 	<collection name="markers" referenced-type="GeneticMarker" reverse-reference="qtls"/>
 # </class>
-type QTL implements Annotatable {
+type QTL implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/QTLStudy.graphql
+++ b/src/types/QTLStudy.graphql
@@ -6,7 +6,7 @@
 # 	<reference name="dataSet" referenced-type="DataSet"/>
 # 	<collection name="qtls" referenced-type="QTL" reverse-reference="qtlStudy"/>
 # </class>
-type QTLStudy implements Annotatable {
+type QTLStudy implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/SequenceFeatureInterface.graphql
+++ b/src/types/SequenceFeatureInterface.graphql
@@ -14,7 +14,7 @@
 # 	<collection name="overlappingFeatures" referenced-type="SequenceFeature"/>
 # 	<collection name="childFeatures" referenced-type="SequenceFeature"/>
 # </class>
-type SequenceFeature implements SequenceFeatureInterface {
+interface SequenceFeature implements BioEntity {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/Supercontig.graphql
+++ b/src/types/Supercontig.graphql
@@ -1,5 +1,5 @@
 # <class name="Supercontig" extends="SequenceFeature" is-interface="true" term="http://purl.obolibrary.org/obo/SO_0000148"></class>
-type Supercontig implements SequenceFeature & BioEntity & Annotatable {
+type Supercontig implements SequenceFeatureInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/SyntenicRegion.graphql
+++ b/src/types/SyntenicRegion.graphql
@@ -1,7 +1,7 @@
 # <class name="SyntenicRegion" extends="SequenceFeature" is-interface="true" term="http://purl.obolibrary.org/obo/SO_0005858">
 # 	<reference name="syntenyBlock" referenced-type="SyntenyBlock" reverse-reference="syntenicRegions"/>
 # </class>
-type SyntenicRegion implements SequenceFeature & BioEntity & Annotatable {
+type SyntenicRegion implements SequenceFeatureInterface {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/Trait.graphql
+++ b/src/types/Trait.graphql
@@ -8,7 +8,7 @@
 # 	<collection name="qtls" referenced-type="QTL" reverse-reference="trait"/>
 # 	<collection name="gwasResults" referenced-type="GWASResult" reverse-reference="trait"/>
 # </class>
-type Trait implements Annotatable {
+type Trait implements AnnotatableInterface {
   # Annotatable
   id: ID!
   identifier: ID!

--- a/src/types/TranscriptInterface.graphql
+++ b/src/types/TranscriptInterface.graphql
@@ -10,7 +10,7 @@
 # 	<collection name="UTRs" referenced-type="UTR" reverse-reference="transcripts"/>
 # 	<collection name="panGeneSets" referenced-type="PanGeneSet" reverse-reference="transcripts"/>
 # </class>
-type Transcript implements TranscriptInterface {
+interface TranscriptInterface implements SequenceFeature {
   id: ID!
   ## Annotatable
   identifier: ID!

--- a/src/types/UTR.graphql
+++ b/src/types/UTR.graphql
@@ -1,7 +1,7 @@
 # <class name="UTR" extends="SequenceFeature" is-interface="true" term="http://purl.obolibrary.org/obo/SO:0000203">
 # 	<collection name="transcripts" referenced-type="Transcript" reverse-reference="UTRs"/>
 # </class>
-type UTR implements SequenceFeature & BioEntity & Annotatable {
+type UTR implements SequenceFeatureInterface {
   id: ID!
   ## Annotatable
   identifier: ID!


### PR DESCRIPTION
I want to be able to resolve the types formerly interfaces to simplify resolution a LOT. So I renamed the interfaces to FooInterface. Foo simply implements FooInterface without any extra fields.