### PR TITLE
Results count

### DIFF
--- a/src/data-sources/intermine/api/get-authors.ts
+++ b/src/data-sources/intermine/api/get-authors.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo
+    countResponse2graphqlPageInfo
 } from '../intermine.server.js';
 import {
     GraphQLAuthor,
@@ -43,8 +43,8 @@ export async function getAuthors(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineAuthorResponse) => response2authors(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Author.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-data-sets.ts
+++ b/src/data-sources/intermine/api/get-data-sets.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLBioEntity,
@@ -63,8 +63,8 @@ export async function getDataSetsForBioEntity(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'DataSet.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
@@ -88,8 +88,8 @@ export async function getDataSetsForGeneticMap(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GeneticMap.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
@@ -113,8 +113,8 @@ export async function getDataSetsForLinkageGroup(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'LinkageGroup.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
@@ -138,8 +138,8 @@ export async function getDataSetsForLocation(
     const dataPromise = this.pathQuery(query,  {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Location.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
@@ -163,8 +163,8 @@ export async function getDataSetsForOntology(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Ontology.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
@@ -188,8 +188,8 @@ export async function getDataSetsForOntologyAnnotation(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'OntologyAnnotation.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
@@ -213,8 +213,8 @@ export async function getDataSetsForOntologyTerm(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'OntologyTerm.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
@@ -237,8 +237,8 @@ export async function getDataSetsForPanGeneSet(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'PanGeneSet.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
@@ -261,8 +261,8 @@ export async function getDataSetsForPathway(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Pathway.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
@@ -285,8 +285,8 @@ export async function getDataSetsForPhylotree(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Phylotree.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));
@@ -310,8 +310,8 @@ export async function getDataSetsForSyntenyBlock(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineDataSetResponse) => response2dataSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'SyntenyBlock.dataSets.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-expression-samples.ts
+++ b/src/data-sources/intermine/api/get-expression-samples.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLExpressionSample,
@@ -43,8 +43,8 @@ export async function getExpressionSamples(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineExpressionSampleResponse) => response2expressionSamples(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'ExpressionSample.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-gene-families.ts
+++ b/src/data-sources/intermine/api/get-gene-families.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGeneFamily,
@@ -43,8 +43,8 @@ export async function getGeneFamilies(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGeneFamilyResponse) => response2geneFamilies(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GeneFamily.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-gene-family-assignments-for-protein.ts
+++ b/src/data-sources/intermine/api/get-gene-family-assignments-for-protein.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
   GraphQLGeneFamilyAssignment,
@@ -31,8 +31,8 @@ export async function getGeneFamilyAssignmentsForProtein(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGeneFamilyAssignmentResponse) => response2geneFamilyAssignments(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Protein.geneFamilyAssignments.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-gene-family-assignments.ts
+++ b/src/data-sources/intermine/api/get-gene-family-assignments.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
   GraphQLGene,
@@ -31,8 +31,8 @@ export async function getGeneFamilyAssignments(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGeneFamilyAssignmentResponse) => response2geneFamilyAssignments(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Gene.geneFamilyAssignments.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-gene-family-tallies.ts
+++ b/src/data-sources/intermine/api/get-gene-family-tallies.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGeneFamily,
@@ -43,8 +43,8 @@ export async function getGeneFamilyTallies(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGeneFamilyTallyResponse) => response2geneFamilyTallies(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GeneFamilyTally.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-genes.ts
+++ b/src/data-sources/intermine/api/get-genes.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGene,
@@ -64,8 +64,8 @@ export async function getGenes(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGeneResponse) => response2genes(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Gene.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-genetic-markers.ts
+++ b/src/data-sources/intermine/api/get-genetic-markers.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGeneticMarker,
@@ -50,8 +50,8 @@ export async function getGeneticMarkers(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGeneticMarkerResponse) => response2geneticMarkers(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GeneticMarker.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-genotyping-platforms.ts
+++ b/src/data-sources/intermine/api/get-genotyping-platforms.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGeneticMarker,
@@ -39,8 +39,8 @@ export async function getGenotypingPlatforms(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGenotypingPlatformResponse) => response2genotypingPlatforms(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GenotypingPlatform.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-gwas-results.ts
+++ b/src/data-sources/intermine/api/get-gwas-results.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
   GraphQLGeneticMarker,
@@ -51,8 +51,8 @@ export async function getGWASResults(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGWASResultResponse) => response2gwasResults(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GWASResult.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-linkage-group-positions.ts
+++ b/src/data-sources/intermine/api/get-linkage-group-positions.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
   GraphQLGeneticMarker,
@@ -32,8 +32,8 @@ export async function getLinkageGroupPositions(
     const dataPromise = this.pathQuery(query, {page, pageSize})
       .then((response: IntermineLinkageGroupPositionResponse) => response2linkageGroupPositions(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GeneticMarker.linkageGroupPositions.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-linkage-groups.ts
+++ b/src/data-sources/intermine/api/get-linkage-groups.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
   GraphQLGeneticMap,
@@ -39,8 +39,8 @@ export async function getLinkageGroups(
     const dataPromise = this.pathQuery(query, {page, pageSize})
       .then((response: IntermineLinkageGroupResponse) => response2linkageGroups(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'LinkageGroup.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-locations.ts
+++ b/src/data-sources/intermine/api/get-locations.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
   GraphQLLocation,
@@ -39,8 +39,8 @@ export async function getLocations(
     const dataPromise = this.pathQuery(query, {page, pageSize})
       .then((response: IntermineLocationResponse) => response2locations(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Location.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-ontology-annotations.ts
+++ b/src/data-sources/intermine/api/get-ontology-annotations.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLAnnotatable,
@@ -43,8 +43,8 @@ export async function getOntologyAnnotations(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineOntologyAnnotationResponse) => response2ontologyAnnotations(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'OntologyAnnotation.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-ontology-terms.ts
+++ b/src/data-sources/intermine/api/get-ontology-terms.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
   GraphQLOntologyTerm,
@@ -39,8 +39,8 @@ export async function getOntologyTerms(
     const dataPromise = this.pathQuery(query, {page, pageSize})
       .then((response: IntermineOntologyTermResponse) => response2ontologyTerms(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'OntologyTerm.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-pan-gene-sets.ts
+++ b/src/data-sources/intermine/api/get-pan-gene-sets.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGene,
@@ -48,8 +48,8 @@ export async function getPanGeneSets(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: InterminePanGeneSetResponse) => response2panGeneSets(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'PanGeneSet.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-pathways.ts
+++ b/src/data-sources/intermine/api/get-pathways.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGene,
@@ -43,8 +43,8 @@ export async function getPathways(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: InterminePathwayResponse) => response2pathways(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Pathway.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-phylonodes.ts
+++ b/src/data-sources/intermine/api/get-phylonodes.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLPhylonode,
@@ -48,8 +48,8 @@ export async function getPhylonodes(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: InterminePhylonodeResponse) => response2phylonodes(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Phylonode.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-protein-domains.ts
+++ b/src/data-sources/intermine/api/get-protein-domains.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGene,
@@ -50,8 +50,8 @@ export async function getProteinDomains(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineProteinDomainResponse) => response2proteinDomains(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'ProteinDomain.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-proteins.ts
+++ b/src/data-sources/intermine/api/get-proteins.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGene,
@@ -57,8 +57,8 @@ export async function getProteins(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineProteinResponse) => response2proteins(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Protein.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-publications.ts
+++ b/src/data-sources/intermine/api/get-publications.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLAnnotatable,
@@ -50,8 +50,8 @@ export async function getPublications(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: InterminePublicationResponse) => response2publications(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Publication.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-qtls.ts
+++ b/src/data-sources/intermine/api/get-qtls.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGeneticMarker,
@@ -57,8 +57,8 @@ export async function getQTLs(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineQTLResponse) => response2qtls(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'QTL.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-strains.ts
+++ b/src/data-sources/intermine/api/get-strains.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
   GraphQLOrganism,
@@ -38,8 +38,8 @@ Promise<ApiResponse<GraphQLStrain[]>> {
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineStrainResponse) => response2strains(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Strain.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/get-syntenic-regions.ts
+++ b/src/data-sources/intermine/api/get-syntenic-regions.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLSyntenicRegion,
@@ -43,8 +43,8 @@ export async function getSyntenicRegions(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineSyntenicRegionResponse) => response2syntenicRegions(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'SyntenicRegion.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-expression-samples.ts
+++ b/src/data-sources/intermine/api/search-expression-samples.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo
+    countResponse2graphqlPageInfo
 } from '../intermine.server.js';
 import {
     GraphQLExpressionSample,
@@ -42,8 +42,8 @@ export async function searchExpressionSamples(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineExpressionSampleResponse) => response2expressionSamples(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'ExpressionSample.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-expression-sources.ts
+++ b/src/data-sources/intermine/api/search-expression-sources.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo
+    countResponse2graphqlPageInfo
 } from '../intermine.server.js';
 import {
     GraphQLExpressionSource,
@@ -42,8 +42,8 @@ export async function searchExpressionSources(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineExpressionSourceResponse) => response2expressionSources(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'ExpressionSource.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-expression-values.ts
+++ b/src/data-sources/intermine/api/search-expression-values.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo
+    countResponse2graphqlPageInfo
 } from '../intermine.server.js';
 import {
     GraphQLExpressionValue,
@@ -54,8 +54,8 @@ export async function searchExpressionValues(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineExpressionValueResponse) => response2expressionValues(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'ExpressionValue.value'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-gene-families.ts
+++ b/src/data-sources/intermine/api/search-gene-families.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGeneFamily,
@@ -42,8 +42,8 @@ export async function searchGeneFamilies(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGeneFamilyResponse) => response2geneFamilies(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GeneFamily.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-genes.ts
+++ b/src/data-sources/intermine/api/search-genes.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGene,
@@ -77,8 +77,8 @@ export async function searchGenes(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGeneResponse) => response2genes(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Gene.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-genetic-maps.ts
+++ b/src/data-sources/intermine/api/search-genetic-maps.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGeneticMap,
@@ -42,8 +42,8 @@ export async function searchGeneticMaps(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGeneticMapResponse) => response2geneticMaps(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GeneticMap.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-gwases.ts
+++ b/src/data-sources/intermine/api/search-gwases.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLGWAS,
@@ -42,8 +42,8 @@ export async function searchGWASes(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineGWASResponse) => response2gwas(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'GWAS.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-ontology-terms.ts
+++ b/src/data-sources/intermine/api/search-ontology-terms.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLOntologyTerm,
@@ -42,8 +42,8 @@ export async function searchOntologyTerms(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineOntologyTermResponse) => response2ontologyTerms(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'OntologyTerm.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-organisms.ts
+++ b/src/data-sources/intermine/api/search-organisms.ts
@@ -1,10 +1,10 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     intermineNotNullConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLOrganism,
@@ -64,8 +64,8 @@ export async function searchOrganisms(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineOrganismResponse) => response2organisms(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Organism.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-protein-domains.ts
+++ b/src/data-sources/intermine/api/search-protein-domains.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLProteinDomain,
@@ -42,8 +42,8 @@ export async function searchProteinDomains(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineProteinDomainResponse) => response2proteinDomains(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'ProteinDomain.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-proteins.ts
+++ b/src/data-sources/intermine/api/search-proteins.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLProtein,
@@ -42,8 +42,8 @@ export async function searchProteins(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineProteinResponse) => response2proteins(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Protein.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-publications.ts
+++ b/src/data-sources/intermine/api/search-publications.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLPublication,
@@ -42,8 +42,8 @@ export async function searchPublications(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: InterminePublicationResponse) => response2publications(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Publication.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-qtl-studies.ts
+++ b/src/data-sources/intermine/api/search-qtl-studies.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLQTLStudy,
@@ -42,8 +42,8 @@ export async function searchQTLStudies(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineQTLStudyResponse) => response2qtlStudies(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'QTLStudy.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-qtls.ts
+++ b/src/data-sources/intermine/api/search-qtls.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLQTL,
@@ -42,8 +42,8 @@ export async function searchQTLs(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineQTLResponse) => response2qtls(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'QTL.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-strains.ts
+++ b/src/data-sources/intermine/api/search-strains.ts
@@ -1,9 +1,9 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLStrain,
@@ -51,8 +51,8 @@ export async function searchStrains(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineStrainResponse) => response2strains(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Strain.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/api/search-traits.ts
+++ b/src/data-sources/intermine/api/search-traits.ts
@@ -1,10 +1,10 @@
 import {
     ApiResponse,
-    IntermineSummaryResponse,
+    IntermineCountResponse,
     intermineConstraint,
     intermineNotNullConstraint,
     interminePathQuery,
-    response2graphqlPageInfo,
+    countResponse2graphqlPageInfo,
 } from '../intermine.server.js';
 import {
     GraphQLTrait,
@@ -72,8 +72,8 @@ export async function searchTraits(
     const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: IntermineTraitResponse) => response2traits(response));
     // get a summary of the data and convert it to page info
-    const pageInfoPromise = this.pathQuery(query, {summaryPath: 'Trait.id'})
-        .then((response: IntermineSummaryResponse) => response2graphqlPageInfo(response, page, pageSize));
+    const pageInfoPromise = this.pathQueryCount(query)
+        .then((response: IntermineCountResponse) => countResponse2graphqlPageInfo(response, page, pageSize));
     // return the expected GraphQL type
     return Promise.all([dataPromise, pageInfoPromise])
         .then(([data, pageInfo]) => ({data, metadata: {pageInfo}}));

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -39,13 +39,17 @@ export class IntermineServer extends RESTDataSource {
         return rest;
     }
 
-    async pathQuery(query: string, options={}) {
+    async pathQuery(query: string, options={}, format='json') {
         const params = {
             query,
             ...this.convertPaginationOptions(options),
-            format: 'json',
+            format,
         };
         return await this.get('query/results', {params});
+    }
+
+    async pathQueryCount(query: string, options={}) {
+        return this.pathQuery(query, options, 'jsoncount');
     }
 
     async keywordSearch(q: string, options={}) {
@@ -74,6 +78,11 @@ export interface IntermineDataResponse<I> {
 
 export interface IntermineSummaryResponse {
     uniqueValues: number;
+}
+
+
+export interface IntermineCountResponse {
+    count: number;
 }
 
 
@@ -129,6 +138,7 @@ export const result2graphqlObject =
 
 
 // converts an Intermine response into an array of GraphQL types
+// TODO: rename dataResponse2graphqlObjects
 export const response2graphqlObjects =
     <I extends IntermineModel>
     (response: IntermineDataResponse<I>, graphqlAttributes: Array<string>):
@@ -140,9 +150,19 @@ export const response2graphqlObjects =
 
 
 // converts an Intermine response into a GraphQL PageInfo type
+// TODO: rename summaryResponse2graphqlObjects
 export const response2graphqlPageInfo =
     (response: IntermineSummaryResponse, page: number|null, pageSize: number|null):
     GraphQLPageInfo => {
         const numResults = response.uniqueValues;
+        return pageInfoFactory(numResults, page, pageSize);
+    };
+
+
+// converts an Intermine response into a GraphQL PageInfo type
+export const countResponse2graphqlPageInfo =
+    (response: IntermineCountResponse, page: number|null, pageSize: number|null):
+    GraphQLPageInfo => {
+        const numResults = response.count;
         return pageInfoFactory(numResults, page, pageSize);
     };

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -150,8 +150,7 @@ export const response2graphqlObjects =
 
 
 // converts an Intermine response into a GraphQL PageInfo type
-// TODO: rename summaryResponse2graphqlObjects
-export const response2graphqlPageInfo =
+export const summmaryResponse2graphqlPageInfo =
     (response: IntermineSummaryResponse, page: number|null, pageSize: number|null):
     GraphQLPageInfo => {
         const numResults = response.uniqueValues;


### PR DESCRIPTION
This PR adds a `pathQueryCount` method to the InterMine data source and uses it to compute pagination info for queries in place of the finicky `summaryPath` queries.

I haven't been able to thoroughly test this but I've confirmed it works on all queries that our Web Components are using.