### PR TITLE
Updated the intermine data source to use POST instead of GET requests

### DIFF
--- a/src/data-sources/intermine/api/get-gene.ts
+++ b/src/data-sources/intermine/api/get-gene.ts
@@ -13,8 +13,11 @@ import {
 
 
 // get a Gene by ID
-export async function getGene(identifier: string):
+export async function getGene(identifier: string, fields: string[]=[]):
 Promise<ApiResponse<GraphQLGene>> {
+    if (fields.indexOf('identifier') !== -1 && fields.length == 1) {
+      return Promise.resolve({data: {identifier}});
+    }
     const constraints = [intermineConstraint('Gene.primaryIdentifier', '=', identifier)];
     const query = interminePathQuery(
         intermineGeneAttributes,

--- a/src/data-sources/intermine/api/get-pan-gene-pairs.ts
+++ b/src/data-sources/intermine/api/get-pan-gene-pairs.ts
@@ -73,7 +73,7 @@ export async function getPanGenePairs(
         joins,
     );
     // get the data
-    const dataPromise = this.pathQueryPost(query, {page, pageSize})
+    const dataPromise = this.pathQuery(query, {page, pageSize})
         .then((response: InterminePanGenePairResponse) => response2panGenePairs(response));
     // get a count of the data and convert it to page info
     // TODO: this count query isn't correct because it's counting the number of genes before the outer join
@@ -83,7 +83,7 @@ export async function getPanGenePairs(
     // TODO: these counts are incorrect because it's counting nested tables from the outer join
     //const resultsInfoPromise = this.pathQuerySummary(query, interminePanGenePairSummaryPath)
     //    .then((response: IntermineSummaryResponse) => summaryResponse2graphqlResultsInfo(response));
-    const allDataPromise = this.pathQueryPost(query);
+    const allDataPromise = this.pathQuery(query);
     const pageInfoPromise = allDataPromise
         .then((response: InterminePanGenePairResponse) => {
           const fakeCountResponse: IntermineCountResponse = {count: response.results.length};

--- a/src/data-sources/intermine/api/get-pan-gene-pairs.ts
+++ b/src/data-sources/intermine/api/get-pan-gene-pairs.ts
@@ -73,7 +73,7 @@ export async function getPanGenePairs(
         joins,
     );
     // get the data
-    const dataPromise = this.pathQuery(query, {page, pageSize})
+    const dataPromise = this.pathQueryPost(query, {page, pageSize})
         .then((response: InterminePanGenePairResponse) => response2panGenePairs(response));
     // get a count of the data and convert it to page info
     // TODO: this count query isn't correct because it's counting the number of genes before the outer join
@@ -83,7 +83,7 @@ export async function getPanGenePairs(
     // TODO: these counts are incorrect because it's counting nested tables from the outer join
     //const resultsInfoPromise = this.pathQuerySummary(query, interminePanGenePairSummaryPath)
     //    .then((response: IntermineSummaryResponse) => summaryResponse2graphqlResultsInfo(response));
-    const allDataPromise = this.pathQuery(query);
+    const allDataPromise = this.pathQueryPost(query);
     const pageInfoPromise = allDataPromise
         .then((response: InterminePanGenePairResponse) => {
           const fakeCountResponse: IntermineCountResponse = {count: response.results.length};

--- a/src/data-sources/intermine/api/get-pan-gene-set.ts
+++ b/src/data-sources/intermine/api/get-pan-gene-set.ts
@@ -12,8 +12,11 @@ import {
 } from '../models/index.js';
 
 // get a PanGeneSet by primaryIdentifier
-export async function getPanGeneSet(identifier: string):
+export async function getPanGeneSet(identifier: string, fields: string[]=[]):
 Promise<ApiResponse<GraphQLPanGeneSet>> {
+    if (fields.indexOf('identifier') !== -1 && fields.length == 1) {
+      return Promise.resolve({data: {identifier}});
+    }
     const constraints = [intermineConstraint('PanGeneSet.primaryIdentifier', '=', identifier)];
     const query = interminePathQuery(
         interminePanGeneSetAttributes,

--- a/src/data-sources/intermine/intermine.fetcher.ts
+++ b/src/data-sources/intermine/intermine.fetcher.ts
@@ -1,0 +1,16 @@
+import nodeFetch from 'node-fetch';
+import { RequestOptions } from '@apollo/datasource-rest';
+
+
+// wraps the default RESTDataSource fetcher (i.e. nodeFetch) to remove cache
+// busting headers from POST responses
+export async function intermineFetcher(url: string, options: RequestOptions) {
+    return nodeFetch(url, options)
+        .then((response) => {
+            if (options.method === 'POST') {
+                response.headers.delete('cache-control');
+                response.headers.delete('pragma');
+            }
+            return response;
+        });
+}

--- a/src/data-sources/intermine/intermine.fetcher.ts
+++ b/src/data-sources/intermine/intermine.fetcher.ts
@@ -8,7 +8,7 @@ export async function intermineFetcher(url: string, options: RequestOptions) {
     return nodeFetch(url, options)
         .then((response) => {
             response.headers.delete('pragma');
-            response.headers.set('cache-control', 'public, max-age=222');
+            response.headers.set('cache-control', 'public');
             return response;
         });
 }

--- a/src/data-sources/intermine/intermine.fetcher.ts
+++ b/src/data-sources/intermine/intermine.fetcher.ts
@@ -2,8 +2,8 @@ import nodeFetch from 'node-fetch';
 import { RequestOptions } from '@apollo/datasource-rest';
 
 
-// wraps the default RESTDataSource fetcher (i.e. nodeFetch) to remove cache
-// busting headers from POST responses
+// wraps the default RESTDataSource fetcher (i.e. nodeFetch) to force caching
+// of every response
 export async function intermineFetcher(url: string, options: RequestOptions) {
     return nodeFetch(url, options)
         .then((response) => {

--- a/src/data-sources/intermine/intermine.fetcher.ts
+++ b/src/data-sources/intermine/intermine.fetcher.ts
@@ -7,10 +7,8 @@ import { RequestOptions } from '@apollo/datasource-rest';
 export async function intermineFetcher(url: string, options: RequestOptions) {
     return nodeFetch(url, options)
         .then((response) => {
-            if (options.method === 'POST') {
-                response.headers.delete('cache-control');
-                response.headers.delete('pragma');
-            }
+            response.headers.delete('pragma');
+            response.headers.set('cache-control', 'public, max-age=222');
             return response;
         });
 }

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -46,7 +46,7 @@ export class IntermineServer extends RESTDataSource {
 
     async pathQuery(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
         const body = {
-            query: query,
+            query,
             ...this.convertPaginationOptions(options),
             format,
         };

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -3,6 +3,7 @@
 
 import { DataSourceConfig, RESTDataSource } from '@apollo/datasource-rest';
 
+import { intermineFetcher } from './intermine.fetcher.js';
 import { GraphQLModel, IntermineModel } from './models/index.js';
 import {
     GraphQLPageInfo,
@@ -15,7 +16,8 @@ import {
 export class IntermineServer extends RESTDataSource {
 
     constructor(baseURL: string, config: DataSourceConfig={}) {
-        super(config);
+        // use intermine-specific fetcher as default if none provided
+        super({fetch: intermineFetcher, ...config});
         // set the URL all requests will be sent to
         this.baseURL = baseURL;
         // NOTE: RESTDataSource uses the Web API URL interface to add paths to

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -38,6 +38,7 @@ export class IntermineServer extends RESTDataSource {
         }
     }
 
+    // a copy of the default deduplication policy but with support for POST requests
     protected override requestDeduplicationPolicyFor(
       url: URL,
       request: RequestOptions,
@@ -58,6 +59,13 @@ export class IntermineServer extends RESTDataSource {
           this.cacheKeyFor(url, { ...request, method: 'HEAD' }),
         ],
       };
+    }
+
+    // sets the time-to-live for every response; this forces caching of POST requests
+    override cacheOptionsFor() {
+      return {
+        ttl: 222
+      }
     }
 
     // InterMine uses offset pagination but we want to support page-based pagination;

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -156,7 +156,7 @@ export interface IntermineCountResponse {
 
 export interface ApiResponse<G> {
   data: G;
-  metadata: {
+  metadata?: {
     pageInfo?: GraphQLPageInfo;
   };
 }

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -75,10 +75,7 @@ export class IntermineServer extends RESTDataSource {
             'Accept': `application/json;type=${format}`,
             'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
           },
-          // add TTL and cacheKey so POSTs are cached
-          cacheOptions: () => ({
-            ttl: 222,  // seconds; this value was randomly selected
-          }),
+          // add cacheKey so POSTs are cached
           cacheKey: encodedBody,
         };
         return await this.post('query/results', request);

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -60,13 +60,13 @@ export class IntermineServer extends RESTDataSource {
     }
 
     // sends a PathQuery to InterMine as a GET request
-    async pathQueryGet(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
+    async pathQuery(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
         const params = this.pathQueryPayload(query, options, format, summaryPath);
         return await this.get('query/results', {params});
     }
 
     // sends a PathQuery to InterMine as a POST request
-    async pathQuery(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
+    async pathQueryPost(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
         const body = this.pathQueryPayload(query, options, format, summaryPath);
         const encodedBody = new URLSearchParams(body).toString();
         const request = {

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -87,13 +87,13 @@ export class IntermineServer extends RESTDataSource {
     }
 
     // sends a PathQuery to InterMine as a GET request
-    async pathQuery(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
+    async pathQueryGet(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
         const params = this.pathQueryPayload(query, options, format, summaryPath);
         return await this.get('query/results', {params});
     }
 
     // sends a PathQuery to InterMine as a POST request
-    async pathQueryPost(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
+    async pathQuery(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
         const body = this.pathQueryPayload(query, options, format, summaryPath);
         const encodedBody = new URLSearchParams(body).toString();
         const request = {

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -77,7 +77,7 @@ export class IntermineServer extends RESTDataSource {
           },
           // add TTL and cacheKey so POSTs are cached
           cacheOptions: () => ({
-            ttl: Infinity,
+            ttl: 222,  // seconds; this value was randomly selected
           }),
           cacheKey: encodedBody,
         };

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -45,13 +45,22 @@ export class IntermineServer extends RESTDataSource {
     }
 
     async pathQuery(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
-        const params = {
-            query,
+        const body = {
+            query: query,
             ...this.convertPaginationOptions(options),
             format,
-            summaryPath,
         };
-        return await this.get('query/results', {params});
+        if (summaryPath !== undefined) {
+            body['summaryPath'] = summaryPath;
+        }
+        const request = {
+          body: new URLSearchParams(body).toString(),
+          headers: {
+            'Accept': `application/json;type=${format}`,
+            'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
+          },
+        };
+        return await this.post('query/results', request);
     }
 
     async pathQueryCount(query: string, options={}) {

--- a/src/data-sources/intermine/intermine.server.ts
+++ b/src/data-sources/intermine/intermine.server.ts
@@ -45,6 +45,16 @@ export class IntermineServer extends RESTDataSource {
     }
 
     async pathQuery(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
+        const params = {
+            query,
+            ...this.convertPaginationOptions(options),
+            format,
+            summaryPath,
+        };
+        return await this.get('query/results', {params});
+    }
+
+    async pathQueryPost(query: string, options={}, format='json', summaryPath:string|undefined=undefined) {
         const body = {
             query,
             ...this.convertPaginationOptions(options),

--- a/src/resolvers/intermine/pan-gene-pair.ts
+++ b/src/resolvers/intermine/pan-gene-pair.ts
@@ -1,6 +1,7 @@
 import { DataSources, IntermineAPI } from '../../data-sources/index.js';
 import { KeyOfType } from '../../utils/index.js';
 import { ResolverMap } from '../resolver.js';
+import { getQueryFields } from '../utils/query-fields.js';
 
 
 export const panGenePairFactory =
@@ -18,21 +19,24 @@ export const panGenePairFactory =
             },
         },
         PanGenePair: {
-            panGeneSet: async (panGenePair, _, { dataSources }) => {
+            panGeneSet: async (panGenePair, _, { dataSources }, info) => {
+                const fields = getQueryFields(info);
                 const {panGeneSetIdentifier} = panGenePair;
-                return dataSources[sourceName].getPanGeneSet(panGeneSetIdentifier)
+                return dataSources[sourceName].getPanGeneSet(panGeneSetIdentifier, fields)
                     // @ts-ignore: implicit type any error
                     .then(({data: results}) => results);
             },
-            query: async (panGenePair, _, { dataSources }) => {
+            query: async (panGenePair, _, { dataSources }, info) => {
+                const fields = getQueryFields(info);
                 const {queryGeneIdentifier} = panGenePair;
-                return dataSources[sourceName].getGene(queryGeneIdentifier)
+                return dataSources[sourceName].getGene(queryGeneIdentifier, fields)
                     // @ts-ignore: implicit type any error
                     .then(({data: results}) => results);
             },
-            result: async (panGenePair, _, { dataSources }) => {
+            result: async (panGenePair, _, { dataSources }, info) => {
+                const fields = getQueryFields(info);
                 const {resultGeneIdentifier} = panGenePair;
-                return dataSources[sourceName].getGene(resultGeneIdentifier)
+                return dataSources[sourceName].getGene(resultGeneIdentifier, fields)
                     // @ts-ignore: implicit type any error
                     .then(({data: results}) => results);
             },

--- a/src/resolvers/resolver.ts
+++ b/src/resolvers/resolver.ts
@@ -1,4 +1,5 @@
 import { ContextValue } from '../context.js';
+import { GraphQLResolveInfoWithCacheControl } from '@apollo/cache-control-types';
 
 
 export interface Args {
@@ -10,7 +11,7 @@ export interface Args {
 // we're not currently set up to specify either of those types
 // NOTE: the return type should be a GraphQL type, but we're not currently set
 // up to specify that
-export type Resolver = (source: any|Function, args: Args, context: ContextValue) => Promise<any>;
+export type Resolver = (source: any|Function, args: Args, context: ContextValue, info?: GraphQLResolveInfoWithCacheControl) => Promise<any>;
 
 
 export interface SubfieldResolverMap {

--- a/src/resolvers/utils/index.ts
+++ b/src/resolvers/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './query-fields.js';

--- a/src/resolvers/utils/query-fields.ts
+++ b/src/resolvers/utils/query-fields.ts
@@ -1,0 +1,22 @@
+import { GraphQLResolveInfoWithCacheControl } from '@apollo/cache-control-types';
+import { FieldNode } from 'graphql';
+
+function getSelections(node: FieldNode) {
+    if (node &&
+        node.selectionSet &&
+        node.selectionSet.selections &&
+        node.selectionSet.selections.length) {
+        return node.selectionSet.selections;
+    }
+    return [];
+}
+
+// gets the list of subfields specified in the query from the client
+export function getQueryFields(info: GraphQLResolveInfoWithCacheControl) {
+    const {fieldName} = info;
+    const [modelNode] = info.fieldNodes.filter(({kind, name}) => kind === "Field" && name.value === fieldName);
+    const selections = getSelections(modelNode).filter(({kind}) => kind === "Field") as FieldNode[];
+    const nameNodes = selections.map(({name}) => name);
+    const fieldNames = nameNodes.map(({value}) => value);
+    return fieldNames;
+};


### PR DESCRIPTION
Switching to POST requests prevents URLs querystrings from being longer than the Intermine server supports.

I'm not sure if the POST requests (specifically the headers) are being made correctly. Therefore I'm opening a draft PR to emphasize the need for further review and testing.