### PR TITLE
add GeneFamily.phylotree.primaryIdentifier to set of attributes

### DIFF
--- a/src/data-sources/intermine/models/gene-family.ts
+++ b/src/data-sources/intermine/models/gene-family.ts
@@ -10,6 +10,7 @@ export const intermineGeneFamilyAttributes = [
     'GeneFamily.description',
     'GeneFamily.version',
     'GeneFamily.size',
+    'GeneFamily.phylotree.primaryIdentifier',
 ];
 export const intermineGeneFamilySort = 'GeneFamily.primaryIdentifier';
 export type IntermineGeneFamily = [
@@ -17,6 +18,7 @@ export type IntermineGeneFamily = [
     string,
     string,
     number,
+    string,
 ];
 
 export const graphqlGeneFamilyAttributes = [
@@ -24,6 +26,7 @@ export const graphqlGeneFamilyAttributes = [
     'description',
     'version',
     'size',
+    'phylotreeIdentifier',
 ];
 export type GraphQLGeneFamily = {
     [prop in typeof graphqlGeneFamilyAttributes[number]]: string;


### PR DESCRIPTION
which seemingly was the reason for the asymmetric behavior of phylotree->genefam vs genefam->phylotree
should fix #179
