### PR TITLE
Newick

### DIFF
--- a/src/data-sources/intermine/models/newick.ts
+++ b/src/data-sources/intermine/models/newick.ts
@@ -1,31 +1,31 @@
 import { IntermineDataResponse, response2graphqlObjects } from '../intermine.server.js';
 
 export const intermineNewickAttributes = [
-    'Newick.identifier',
-    'Newick.contents',
-    'Newick.phylotree.primaryIdentifier',
-    'Newick.geneFamily.primaryIdentifier',
+  'Newick.identifier',
+  'Newick.contents',
+  'Newick.phylotree.primaryIdentifier',
+  'Newick.geneFamily.primaryIdentifier',
 ];
 export const intermineNewickSort = 'Newick.identifier';
 export type IntermineNewick = [
-    string,
-    string,
-    number,
-    number,
+  string,
+  string,
+  number,
+  number,
 ];
 
 export const graphqlNewickAttributes = [
-    'identifier',
-    'contents',
-    'phylotreeIdentifier',
-    'geneFamilyIdentifier',
+  'identifier',
+  'contents',
+  'phylotreeIdentifier',
+  'geneFamilyIdentifier',
 ];
 export type GraphQLNewick = {
-    [prop in typeof graphqlNewickAttributes[number]]: string;
+  [prop in typeof graphqlNewickAttributes[number]]: string;
 }
 
 
 export type IntermineNewickResponse = IntermineDataResponse<IntermineNewick>;
 export function response2newicks(response: IntermineNewickResponse): Array<GraphQLNewick> {
-    return response2graphqlObjects(response, graphqlNewickAttributes);
+  return response2graphqlObjects(response, graphqlNewickAttributes);
 }

--- a/src/resolvers/intermine/phylotree.ts
+++ b/src/resolvers/intermine/phylotree.ts
@@ -20,14 +20,14 @@ ResolverMap => ({
     Phylotree: {
         ...isAnnotatableFactory(sourceName),
         ...hasGeneFamilyFactory(sourceName),
-        //newick: async(phylotree, _, { dataSources }) => {
-        //    return dataSources[sourceName].getNewick(phylotree.identifier)
-        //        // @ts-ignore: implicit type any error
-        //        .then(({data: newick}) => {
-        //            if (newick != null) return newick.contents;
-        //            return null;
-        //        });
-        //},
+        newick: async(phylotree, _, { dataSources }) => {
+            return dataSources[sourceName].getNewick(phylotree.identifier)
+                // @ts-ignore: implicit type any error
+                .then(({data: newick}) => {
+                    if (newick != null) return newick.contents;
+                    return null;
+                });
+        },
         nodes: async (phylotree, { page, pageSize }, { dataSources }) => {
             const {id} = phylotree;
             return dataSources[sourceName].getPhylonodesForPhylotree(id, {page, pageSize})

--- a/src/types/Phylotree.graphql
+++ b/src/types/Phylotree.graphql
@@ -10,6 +10,7 @@ type Phylotree implements Annotatable
   # HasGeneFamily
   geneFamily: GeneFamily
   # Phylotree
+  newick: String
   nodes: [Phylonode!]!
   numLeaves: Int
 }


### PR DESCRIPTION
Adds back the previously implemented `newick` property of the `Phylotree` type. Shout out to @adf-ncgr for fixing a bug (PR #180) that this uncovered.