### PR TITLE
Updated build-publish workflow runner

### DIFF
--- a/.github/workflows/build-push-on-tag.yml
+++ b/.github/workflows/build-push-on-tag.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build-and-push-image:
     name: 'graphql-server Docker image build and push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Previously the runner used Ubuntu 20.04, which GitHub has deprecated. It now uses the latest version of Ubuntu so deprecation should not be a future issue.